### PR TITLE
Small client action items

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,6 @@
+# DNS
+export BASE_URL="http://localhost:3000"
+
 # Database
 export DB_HOST="localhost"
 export DB_USER="cru"

--- a/app/admin/course.rb
+++ b/app/admin/course.rb
@@ -1,5 +1,7 @@
 ActiveAdmin.register Course do
-  permit_params :name, :start_at, :end_at
+  permit_params :name, :description, :start_at, :end_at
+
+  action_item(:new, only: :show) { link_to 'New Class', new_course_path }
 
   index do
     selectable_column
@@ -29,9 +31,8 @@ ActiveAdmin.register Course do
         attributes_table do
           row :id
           row :name
-          # rubocop:disable Rails/OutputSafety
-          row(:description) { |m| m.description.try(:html_safe) }
-          row :stat_at
+          row(:description) { |m| html_summary(m.description) }
+          row :start_at
           row :end_at
           row :created_at
           row :updated_at

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -1,6 +1,8 @@
 ActiveAdmin.register User do
   permit_params :role, :email
 
+  action_item(:new, only: :show) { link_to 'New User', new_user_path }
+
   index do
     selectable_column
     id_column

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -1,2 +1,2 @@
-class CoursePolicy < FinancePolicy
+class CoursePolicy < ReadOnlyPolicy
 end

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -100,8 +100,9 @@ ActiveAdmin.setup do |config|
   # a string, the strings is used as the path. If it's a Symbol, we
   # will call the method to return the path.
   #
-  # Default:
-  config.logout_link_path = '/logout' # Handled by gem `rack-cas`
+  # NOTE: This path is currently handled by gem `rack-cas`
+  # SEE:  https://wiki.jasig.org/display/CAS/gateway
+  config.logout_link_path = "/logout?gateway=true&service=#{CGI.escape(ENV['BASE_URL'])}"
 
   # This setting changes the http method used when rendering the
   # link. For example :get, :delete, :put, etc..

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -8,8 +8,8 @@ class CourseTest < ActiveSupport::TestCase
 
   test 'permit create' do
     refute_permit @general_user, @course, :create
+    refute_permit @finance_user, @course, :create
 
-    assert_permit @finance_user, @course, :create
     assert_permit @admin_user, @course, :create
   end
 
@@ -21,15 +21,15 @@ class CourseTest < ActiveSupport::TestCase
 
   test 'permit update' do
     refute_permit @general_user, @course, :update
+    refute_permit @finance_user, @course, :update
 
-    assert_permit @finance_user, @course, :update
     assert_permit @admin_user, @course, :update
   end
 
   test 'permit destroy' do
     refute_permit @general_user, @course, :destroy
+    refute_permit @finance_user, @course, :destroy
 
-    assert_permit @finance_user, @course, :destroy
     assert_permit @admin_user, @course, :destroy
   end
 end


### PR DESCRIPTION
This PR combines the client action-items for a few stories which are too small to stand on their own.

### Stories
  * [#128092577 As an Admin user, I can add/edit/remove any class with a start/end date](https://www.pivotaltracker.com/story/show/128092577)
  * [#128092543 As a user, I can sign out from the system from any page.](https://www.pivotaltracker.com/story/show/128092543)
  * [#128092545 As an admin user, I can add other users to the system making him an admin or not.](https://www.pivotaltracker.com/story/show/128092545)

### Changes

  * An `Add New FooBar` button has been added to `users#show` and `courses#show`.
  * When the user logs out, they are redirected back to the site's homepage
  * typo: `stat_at -> start_at`
  * Add `course#description` to `permit_params`
  * Update the policy for Courses so that only Admin users can edit them (not Finance users).