### PR TITLE
Add "New" button to every #show page

### DIFF
--- a/app/admin/course.rb
+++ b/app/admin/course.rb
@@ -1,8 +1,6 @@
 ActiveAdmin.register Course do
   permit_params :name, :description, :start_at, :end_at
 
-  action_item(:new, only: :show) { link_to 'New Class', new_course_path }
-
   index do
     selectable_column
     column :id

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -1,8 +1,6 @@
 ActiveAdmin.register User do
   permit_params :role, :email
 
-  action_item(:new, only: :show) { link_to 'New User', new_user_path }
-
   index do
     selectable_column
     id_column

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -1,5 +1,7 @@
 require 'active_admin/axlsx'
 
+ActiveAdmin::Resource.include(ActiveAdmin::Resource::AdditionalActionItems)
+
 ActiveAdmin.setup do |config|
   # == Site Title
   #

--- a/lib/active_admin/resource/additional_action_items.rb
+++ b/lib/active_admin/resource/additional_action_items.rb
@@ -1,0 +1,38 @@
+module ActiveAdmin
+    class Resource
+      # @see https://github.com/activeadmin/activeadmin/blob/master/lib/active_admin/resource/action_items.rb
+      module AdditionalActionItems
+        def initialize(*args)
+          add_additional_action_items
+          super
+        end
+
+        private
+
+        def add_additional_action_items
+          add_additional_new_action_item
+        end
+
+        # Adds the default New link on :show. Normally it's only on :index.
+        def add_additional_new_action_item
+          add_action_item :new_show, only: :show do
+            permitted =
+              authorized?(
+                ActiveAdmin::Auth::CREATE,
+                active_admin_config.resource_class
+              )
+
+            if controller.action_methods.include?('new') && permitted
+              link_to(
+                I18n.t(
+                  'active_admin.new_model',
+                  model: active_admin_config.resource_label
+                ),
+                new_resource_path
+              )
+            end
+          end
+        end
+      end
+    end
+end


### PR DESCRIPTION
Completes [PT #132576193: Add "Create" button on all view screens](https://www.pivotaltracker.com/story/show/132576193)

This story makes it so when you are viewing any individual record page (the `#show` action), there will be a "New FooBar" button at the top of the page. Normally this button only appears by default on `#index` pages.