### PR TITLE
Show ActiveAdmin comments form on all #edit pages

### DIFF
--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -1,7 +1,5 @@
 require 'active_admin/axlsx'
 
-ActiveAdmin::Resource.include(ActiveAdmin::Resource::AdditionalActionItems)
-
 ActiveAdmin.setup do |config|
   # == Site Title
   #

--- a/config/initializers/active_admin_custom.rb
+++ b/config/initializers/active_admin_custom.rb
@@ -1,0 +1,11 @@
+# This initializer includes ActiveAdmin customization beyond the out-of-the-box
+# configuration.
+
+# Add extra buttons to the #show page
+ActiveAdmin::Resource.include(ActiveAdmin::Resource::AdditionalActionItems)
+
+# Show comments form on #edit pages too
+require 'active_admin/comments/edit_page_helper'
+ActiveAdmin.application.view_factory.edit_page.send(
+  :include, ActiveAdmin::Comments::EditPageHelper
+)

--- a/lib/active_admin/comments/edit_page_helper.rb
+++ b/lib/active_admin/comments/edit_page_helper.rb
@@ -1,0 +1,18 @@
+module ActiveAdmin
+  module Comments
+    # Adds #active_admin_comments to the edit page for use and sets it up on
+    # the main content
+    module EditPageHelper
+      def self.included(base)
+        base.alias_method_chain(:main_content, :comments)
+      end
+
+      # Add admin comments to the main content if they are
+      # turned on for the current resource
+      def main_content_with_comments
+        main_content_without_comments
+        active_admin_comments_for(resource) if active_admin_config.comments?
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR completes the story [PT #152889609: As a user, I can leave a comment about any attendee.](https://www.pivotaltracker.com/story/show/128092573/comments/152889609). This story was completed recently, but reopened to implement a client action-item.

By default, ActiveAdmin provides the ability to comment on any record from it's `#show` page. The client would like this form also available on any record's `#edit` page as well.

The implementation of this feature is heavily based off the [`show_page_helper.rb`](https://github.com/activeadmin/activeadmin/blob/v1.0.0.pre4/lib/active_admin/orm/active_record/comments/show_page_helper.rb) view helper which provides this functionality for all `#show` pages.