### PR TITLE
Add cost_type enum to CostAssociation

### DIFF
--- a/app/admin/cost_adjustment.rb
+++ b/app/admin/cost_adjustment.rb
@@ -1,11 +1,12 @@
 ActiveAdmin.register CostAdjustment do
-  permit_params :person_id, :price, :description
+  permit_params :person_id, :cost_type, :price, :description
 
   index do
     selectable_column
     column :id
     column('Person') { |ca| link_to(ca.person.full_name, ca.person) }
-    column(:price) { |c| humanized_money_with_symbol(c.price) }
+    column('Type') { |ca| cost_type_name(ca) }
+    column(:price) { |ca| humanized_money_with_symbol(ca.price) }
     column(:description) { |ca| html_summary(ca.description) }
     column :created_at
     column :updated_at
@@ -16,7 +17,8 @@ ActiveAdmin.register CostAdjustment do
     attributes_table do
       row :id
       row('Person') { |ca| link_to(ca.person.full_name, ca.person) }
-      row(:price) { |c| humanized_money_with_symbol(c.price) }
+      row('Type') { |ca| cost_type_name(ca) }
+      row(:price) { |ca| humanized_money_with_symbol(ca.price) }
       row(:description) { |ca| html_summary(ca.description) }
       row :created_at
       row :updated_at
@@ -32,6 +34,7 @@ ActiveAdmin.register CostAdjustment do
     f.semantic_errors
     f.inputs do
       f.input :person
+      f.input :cost_type, as: :select, collection: cost_type_select
       f.input :price, as: :string
       f.input :description, as: :ckeditor
     end

--- a/app/helpers/cost_adjustment_helper.rb
+++ b/app/helpers/cost_adjustment_helper.rb
@@ -1,0 +1,32 @@
+module CostAdjustmentHelper
+  I18N_PREFIX = 'activerecord.attributes.cost_adjustment'.freeze
+
+  module_function
+
+  def cost_type_select
+    CostAdjustment.cost_types.map do |type, value|
+      [cost_type_name(value), type]
+    end
+  end
+
+  # @param [ApplicationRecord, Fixnum] obj - either a record with a
+  #   {cost_type} field, or the ordinal value of the
+  #   {CostAdjustment#cost_type} enum
+  # @return [String] the translated name of that type
+  def cost_type_name(obj)
+    # typecast an integer into an enum string
+    type =
+      case obj
+      when ApplicationRecord
+        obj.cost_type
+      when Fixnum
+        CostAdjustment.new(cost_type: obj).cost_type
+      when nil
+        nil
+      else
+        raise "unexpected parameter, '#{obj.inspect}'"
+      end
+
+    I18n.t("#{I18N_PREFIX}.cost_types.#{type}")
+  end
+end

--- a/app/helpers/views_helper.rb
+++ b/app/helpers/views_helper.rb
@@ -42,4 +42,12 @@ module ViewsHelper
   def family_name(family)
     ::PersonHelper.family_name(family)
   end
+
+  def cost_type_select
+    ::CostAdjustmentHelper.cost_type_select
+  end
+
+  def cost_type_name(obj)
+    ::CostAdjustmentHelper.cost_type_name(obj)
+  end
 end

--- a/app/models/cost_adjustment.rb
+++ b/app/models/cost_adjustment.rb
@@ -1,10 +1,16 @@
-class CostAdjustment < ActiveRecord::Base
+class CostAdjustment < ApplicationRecord
   include Monetizable
 
   monetize_attr :price_cents, numericality: {
     greater_than_or_equal_to: -1_000_000,
     less_than_or_equal_to:     1_000_000
   }
+
+  # MPD is "Ministry Partner Development"
+  enum cost_type: [
+    :dorm_adult, :dorm_child, :apartment_rent, :facility_use, :tuition_class,
+    :tuition_mpd, :tuition_track, :tuition_staff, :books
+  ]
 
   belongs_to :person, foreign_key: 'person_id'
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,6 +27,17 @@ en:
         other: Classes
 
     attributes:
+      cost_adjustment:
+        cost_types:
+          dorm_adult: "Adult Dorm (room & board) Charges"
+          dorm_child: "Child Dorm (room & board) Charges"
+          apartment_rent: "Apartment Rent"
+          facility_use: "Facility Use Fee for Off Campus Residents"
+          tuition_class: "Class Tuition"
+          tuition_mpd: "MPD Tuition"
+          tuition_track: "Track Tuition"
+          tuition_staff: "Staff Conference Tuition"
+          books: "Books"
       family:
         country_code: Country
         phone: Phone Number

--- a/db/migrate/20161019181131_add_cost_type_to_cost_adjustments.rb
+++ b/db/migrate/20161019181131_add_cost_type_to_cost_adjustments.rb
@@ -1,0 +1,5 @@
+class AddCostTypeToCostAdjustments < ActiveRecord::Migration
+  def change
+    add_column :cost_adjustments, :cost_type, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20161019211535_remove_cost_type_default_from_cost_adjustments.rb
+++ b/db/migrate/20161019211535_remove_cost_type_default_from_cost_adjustments.rb
@@ -1,0 +1,5 @@
+class RemoveCostTypeDefaultFromCostAdjustments < ActiveRecord::Migration
+  def change
+    change_column_default :cost_adjustments, :cost_type, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160928162928) do
+ActiveRecord::Schema.define(version: 20161019211535) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace"
@@ -65,6 +65,7 @@ ActiveRecord::Schema.define(version: 20160928162928) do
     t.text     "description"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.integer  "cost_type",   null: false
   end
 
   add_index "cost_adjustments", ["person_id"], name: "index_cost_adjustments_on_person_id"

--- a/test/factories/cost_adjustment.rb
+++ b/test/factories/cost_adjustment.rb
@@ -3,5 +3,6 @@ FactoryGirl.define do
     person factory: :attendee
     price_cents { Faker::Number.between(0, 1000_00) }
     description { Faker::Lorem.paragraph(rand(3)) }
+    cost_type { CostAdjustment.cost_types.values.sample }
   end
 end


### PR DESCRIPTION
This PR completes story [PT #128092579: As a finance user, I can add/remove cost adjustments to any attendee.](https://www.pivotaltracker.com/story/show/128092579).

The client added an action item to this story indicating that the `CostAdjustment` model should have a "type" attribute.  This attribute can be one of the following options:

 * Adult Dorm (room & board) Charges
 * Child Dorm (room & board) Charges
 * Apartment Rent
 * Facility Use Fee for Off Campus Residents
 * Class Tuition
 * MPD Tuition
 * Track Tuition
 * Books
 * Staff Conference Tuition