### PR TITLE
Family last name

### DIFF
--- a/app/admin/attendee.rb
+++ b/app/admin/attendee.rb
@@ -6,6 +6,9 @@ ActiveAdmin.register Attendee do
 
   menu parent: 'People', priority: 2
 
+  # We create through Families#show
+  config.remove_action_item :new
+
   permit_params(
     :first_name, :last_name, :email, :emergency_contact, :phone, :staff_number,
     :student_number, :gender, :department, :family_id, :birthdate, :ministry_id,

--- a/app/admin/attendee.rb
+++ b/app/admin/attendee.rb
@@ -22,9 +22,7 @@ ActiveAdmin.register Attendee do
     column :id
     column(:student_number) { |a| code a.student_number }
     column :first_name
-    column(:last_name) do |a|
-      link_to a.last_name, family_path(a.family) if a.family_id
-    end
+    column(:last_name) { |a| link_to last_name_label(a), family_path(a.family) }
     column :birthdate
     column('Age', sortable: :birthdate) { |a| age(a.birthdate) }
     column(:gender) { |a| gender_name(a.gender) }

--- a/app/admin/child.rb
+++ b/app/admin/child.rb
@@ -11,9 +11,7 @@ ActiveAdmin.register Child do
     selectable_column
     column :id
     column :first_name
-    column(:last_name) do |c|
-      link_to c.last_name, family_path(c.family) if c.family_id
-    end
+    column(:last_name) { |c| link_to last_name_label(c), family_path(c.family) }
     column(:gender) { |c| gender_name(c.gender) }
     column :birthdate
     column('Age', sortable: :birthdate) { |c| age(c.birthdate) }
@@ -29,9 +27,7 @@ ActiveAdmin.register Child do
     attributes_table do
       row :id
       row :first_name
-      row(:last_name) do |c|
-        link_to c.last_name, family_path(c.family) if c.family_id
-      end
+      row(:last_name) { |c| link_to last_name_label(c), family_path(c.family) }
       row(:gender) { |c| gender_name(c.gender) }
       row :birthdate
       row('Age', sortable: :birthdate) { |c| age(c.birthdate) }
@@ -49,9 +45,19 @@ ActiveAdmin.register Child do
     f.semantic_errors
 
     f.inputs do
+      f.input :family, selected: params[:family_id]
+    end
+
+    f.inputs do
       f.input :first_name
-      f.input :last_name
-      f.input :family
+
+      if param_family
+        f.input :last_name, hint: t('misc.family.last_name_default', name:
+                                    param_family.last_name)
+      else
+        f.input :last_name
+      end
+
       f.input :gender, as: :select, collection: gender_select
       f.input :birthdate, as: :datepicker, datepicker_options:
         { changeYear: true, changeMonth: true }

--- a/app/admin/child.rb
+++ b/app/admin/child.rb
@@ -1,7 +1,10 @@
 ActiveAdmin.register Child do
   menu parent: 'People', priority: 3
 
-  permit_params :first_name, :last_name, :birthdate, :gender, :family,
+  # We create through Families#show
+  config.remove_action_item :new
+
+  permit_params :first_name, :last_name, :birthdate, :gender, :family_id,
                 :parent_pickup, :needs_bed, :grade_level, childcare_weeks: []
 
   index do

--- a/app/admin/concerns/attendees/form.rb
+++ b/app/admin/concerns/attendees/form.rb
@@ -14,17 +14,27 @@ module Attendees
     end
 
     AttendeeInputs = proc do |f|
+      f.inputs do
+        f.input :family, selected: param_family.try(:id)
+      end
+
       f.inputs 'Basic' do
         f.input :student_number
         f.input :first_name
-        f.input :last_name
+
+        if param_family
+          f.input :last_name, hint: t('misc.family.last_name_default', name:
+                                      param_family.last_name)
+        else
+          f.input :last_name
+        end
+
         f.input :gender, as: :select, collection: gender_select
         f.input(
           :birthdate,
           as: :datepicker,
           datepicker_options: { changeYear: true, changeMonth: true }
         )
-        f.input :family
       end
 
       f.inputs 'Contact' do

--- a/app/admin/concerns/attendees/show.rb
+++ b/app/admin/concerns/attendees/show.rb
@@ -26,7 +26,7 @@ module Attendees
           row(:student_number) { |a| code a.student_number }
           row :first_name
           row(:last_name) do |a|
-            link_to a.last_name, family_path(a.family) if a.family_id
+            link_to last_name_label(a), family_path(a.family)
           end
           row :birthdate
           row('Age', sortable: :birthdate) { |a| age(a.birthdate) }

--- a/app/admin/family.rb
+++ b/app/admin/family.rb
@@ -78,5 +78,10 @@ ActiveAdmin.register Family do
         end
       end
     end
+
+    div class: 'action_items' do
+      span link_to('New Attendee', new_attendee_path(family_id: family.id)), class: 'action_item'
+      span link_to('New Child', new_child_path(family_id: family.id)), class: 'action_item'
+    end
   end
 end

--- a/app/admin/family.rb
+++ b/app/admin/family.rb
@@ -1,12 +1,12 @@
 ActiveAdmin.register Family do
   menu parent: 'People', priority: 1
 
-  permit_params :phone, :street, :city, :state, :zip, :country_code
+  permit_params :last_name, :phone, :street, :city, :state, :zip, :country_code
 
   index do
     selectable_column
     column :id
-    column('Name') { |f| h4 family_name(f) }
+    column :last_name
     column(:phone) { |f| format_phone(f.phone) }
     column :street
     column :city
@@ -18,9 +18,10 @@ ActiveAdmin.register Family do
     actions
   end
 
-  show title: ->(f) { PersonHelper.family_name(f) } do
+  show title: ->(f) { PersonHelper.family_label(f) } do
     attributes_table do
       row :id
+      row :last_name
       row(:phone) { |f| format_phone(f.phone) }
       row :street
       row :city
@@ -30,13 +31,17 @@ ActiveAdmin.register Family do
       row :created_at
       row :updated_at
     end
+
     active_admin_comments
   end
 
-  form title: ->(f) { "Edit #{PersonHelper.family_name(f)}" } do |f|
+  form title: ->(f) { "Edit #{PersonHelper.family_label(f)}" } do |f|
     f.semantic_errors
 
-    f.inputs :phone
+    f.inputs 'Basic Info' do
+      f.input :last_name
+      f.input :phone
+    end
 
     f.inputs 'Address' do
       f.input :street
@@ -48,6 +53,7 @@ ActiveAdmin.register Family do
     f.actions
   end
 
+  filter :last_name
   filter :phone
   filter :street
   filter :city

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -11,17 +11,14 @@
 @import "active_admin/mixins";
 @import "active_admin/base";
 
+@import "widgets/buttons";
+
 //  Specific Models
 //  =================================
 
 //  Attendee ------------------------
 @import "attendee/form";
 
-
-// Overriding any non-variable SASS must be done after the fact.
-// For example, to change the default status-tag color:
-//
-//   .status_tag { background: #6090DB; }
 
 // CK Editor Fixes
 // see https://github.com/activeadmin/activeadmin/wiki/Ckeditor-integration

--- a/app/assets/stylesheets/attendee/form.scss
+++ b/app/assets/stylesheets/attendee/form.scss
@@ -1,3 +1,5 @@
+@import "../widgets/buttons";
+
 #new_attendee,
 #edit_attendee {
   /**
@@ -14,31 +16,11 @@
     }
 
     &__new-btn {
+      @extend .action_item_button;
+
       cursor: pointer;
       float: right;
       margin-right: 3em;
-
-      // The rest is copied from ActiveAdmin button style
-      // Unfortunately, this style is currently not @extend-able
-      border-radius: 200px;
-      display: inline-block;
-      font-weight: bold;
-      font-size: 1.0em;
-      font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-      line-height: 12px;
-      padding: 7px 16px 6px;
-      text-decoration: none;
-      background-color: #FFFFFF;
-      background-image: linear-gradient(180deg, #FFFFFF, #E7E7E7);
-      box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1), 0 1px 0 0 rgba(255, 255, 255, 0.8) inset;
-      border: solid 1px #c7c7c7;
-      border-color: #c7c7c7;
-      border-top-color: #d3d3d3;
-      border-right-color: #c7c7c7;
-      border-bottom-color: #c2c2c2;
-      border-left-color: #c7c7c7;
-      text-shadow: #fff 0 1px 0;
-      color: #5E6469;
     }
   }
 }

--- a/app/assets/stylesheets/widgets/buttons.scss
+++ b/app/assets/stylesheets/widgets/buttons.scss
@@ -1,0 +1,59 @@
+/**
+ * ActiveAdmin's default button style is not extendable, as it's rule is
+ * overly-specific (#title_bar .action_items span.action_item), so we re-create
+ * it here, so it can be used in more places.
+ */
+.action_item_button {
+  border-radius: 200px;
+  display: inline-block;
+  font-weight: bold;
+  font-size: 1.0em;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  line-height: 12px;
+  margin-right: 3px;
+  padding: 7px 16px 6px;
+  text-decoration: none;
+  background-color: #fff;
+  background-image: linear-gradient(180deg, #fff, #e7e7e7);
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1), 0 1px 0 0 rgba(255, 255, 255, 0.8) inset;
+  border: solid 1px #c7c7c7;
+  border-color: #c7c7c7;
+  border-top-color: #d3d3d3;
+  border-right-color: #c7c7c7;
+  border-bottom-color: #c2c2c2;
+  border-left-color: #c7c7c7;
+  text-shadow: #fff 0 1px 0;
+  color: #5E6469;
+  padding: 12px 17px 10px;
+  margin: 0px;
+
+  &.disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  &:not(.disabled):hover {
+    background-color: #fff;
+    background-image: linear-gradient(180deg, #fff, #f1f1f1);
+  }
+
+  &:not(.disabled):active {
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.22) inset, 0 1px 0 0px #eee;
+    border-color: #b9b9b9;
+    border-top-color: #c2c2c2;
+    border-right-color: #b9b9b9;
+    border-bottom-color: #b7b7b7;
+    border-left-color: #b9b9b9;
+    background-color: #f3f3f3;
+    background-image: linear-gradient(180deg, #f3f3f3, #d8d8d8);
+  }
+}
+
+
+.action_items {
+  .action_item {
+    & > a, & > .dropdown_menu > a {
+      @extend .action_item_button;
+    }
+  }
+}

--- a/app/controllers/concerns/family_member.rb
+++ b/app/controllers/concerns/family_member.rb
@@ -1,0 +1,13 @@
+module FamilyMember
+  extend ActiveSupport::Concern
+
+  included do
+    before_validation :default_to_family_name, on: :create
+  end
+
+  private
+
+  def default_to_family_name
+    self.last_name = family.last_name if last_name.blank? && family
+  end
+end

--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -1,4 +1,12 @@
 module PersonHelper
+  # @return [Family,nil] The family specified by the `family_id` query param
+  def param_family
+    @param_family ||=
+      if (id = params[:family_id])
+        Family.find(id)
+      end
+  end
+
   module_function
 
   def gender_select
@@ -19,11 +27,15 @@ module PersonHelper
     now.month > dob.month || (now.month == dob.month && now.day >= dob.day)
   end
 
-  def family_name(family)
-    if (last_name = family.people.first.try(:last_name))
-      "#{last_name} Family"
+  def family_label(family)
+    "#{family.last_name} Family ##{family.id}"
+  end
+
+  def last_name_label(person)
+    if person.last_name == person.family.last_name
+      "#{person.last_name} ##{person.family_id}"
     else
-      "Family ##{family.id}"
+      "#{person.last_name} (#{family_label(person.family)})"
     end
   end
 end

--- a/app/helpers/text_helper.rb
+++ b/app/helpers/text_helper.rb
@@ -2,10 +2,6 @@ require 'phone'
 require 'truncate_html'
 
 module TextHelper
-  class << self
-    include ActionView::Helpers::TagHelper
-  end
-
   module_function
 
   def html_summary(html)

--- a/app/helpers/views_helper.rb
+++ b/app/helpers/views_helper.rb
@@ -2,19 +2,29 @@ module ViewsHelper
   # This creates instance methods for all of the module methods from the other
   # helper modules.
   #
-  # The reason every other helper consists of only module methods, and
-  # ViewHelper consists of "instance aliases" of those module methods, is
-  # because:
+  # ViewHelper is the only helper which is automatically mixed into ActiveAdmin
+  # records. This extends all the other helpers so that their helper methods
+  # are available to ActiveAdmin records. It also creates instance methods that
+  # alias the module methods from te other helper modules so that they're also
+  # available.
   #
-  #   1. Only ViewHelper is mixed into ActiveAdmin resources.
-  #   2. ViewHelper's instance methods are not available in the class_eval
-  #      context, so the module methods must be used in those cases.
-  Dir[Rails.root.join('app', 'helpers', '*.rb')].map do |path|
-    File.basename(path, '.rb').camelize.safe_constantize
-  end.compact.each do |mod|
-    (mod.public_methods - Module.public_methods).each do |method_name|
-      method = mod.method(method_name)
-      define_method(method_name) { |*args| instance_exec(*args, &method) }
+  # The reason some helper methods are module methods is because ViewHelper's
+  # instance methods are not available in the class context, so the module
+  # methods must be used in those cases.
+  begin
+    modules =
+      Dir[Rails.root.join('app', 'helpers', '*.rb')].map do |path|
+        File.basename(path, '.rb').camelize.safe_constantize
+      end
+
+    modules.each do |mod|
+      next if mod.nil? || mod == self
+
+      extend mod
+
+      (mod.public_methods - Module.public_methods).each do |method_name|
+        define_method(method_name) { |*args| mod.send(method_name, *args) }
+      end
     end
   end
 end

--- a/app/helpers/views_helper.rb
+++ b/app/helpers/views_helper.rb
@@ -1,45 +1,20 @@
 module ViewsHelper
-  def country_select
-    ::CountryHelper.country_select
-  end
-
-  def country_name(code)
-    ::CountryHelper.country_name(code)
-  end
-
-  def gender_select
-    ::PersonHelper.gender_select
-  end
-
-  def gender_name(g)
-    ::PersonHelper.gender_name(g)
-  end
-
-  def format_phone(number)
-    ::TextHelper.format_phone(number)
-  end
-
-  def html_summary(html)
-    ::TextHelper.html_summary(html)
-  end
-
-  def meal_type_select
-    ::MealHelper.meal_type_select
-  end
-
-  def childcare_weeks_select
-    ::ChildcareHelper.childcare_weeks_select
-  end
-
-  def childcare_spaces_select
-    ::ChildcareHelper.childcare_spaces_select
-  end
-
-  def age(birthdate)
-    ::PersonHelper.age(birthdate)
-  end
-
-  def family_name(family)
-    ::PersonHelper.family_name(family)
+  # This creates instance methods for all of the module methods from the other
+  # helper modules.
+  #
+  # The reason every other helper consists of only module methods, and
+  # ViewHelper consists of "instance aliases" of those module methods, is
+  # because:
+  #
+  #   1. Only ViewHelper is mixed into ActiveAdmin resources.
+  #   2. ViewHelper's instance methods are not available in the class_eval
+  #      context, so the module methods must be used in those cases.
+  Dir[Rails.root.join('app', 'helpers', '*.rb')].map do |path|
+    File.basename(path, '.rb').camelize.safe_constantize
+  end.compact.each do |mod|
+    (mod.public_methods - Module.public_methods).each do |method_name|
+      method = mod.method(method_name)
+      define_method(method_name) { |*args| instance_exec(*args, &method) }
+    end
   end
 end

--- a/app/models/attendee.rb
+++ b/app/models/attendee.rb
@@ -1,4 +1,6 @@
 class Attendee < Person
+  include FamilyMember
+
   # TODO: Housing Preferences
 
   belongs_to :family
@@ -10,4 +12,6 @@ class Attendee < Person
   has_many :meal_exemptions
 
   accepts_nested_attributes_for :meal_exemptions, allow_destroy: true
+
+  validates :family_id, presence: true
 end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -1,4 +1,8 @@
 class Child < Person
+  include FamilyMember
+
   belongs_to :family
   belongs_to :childcare
+
+  validates :family_id, presence: true
 end

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -3,7 +3,9 @@ class Family < ApplicationRecord
   has_many :attendees
   has_many :children
 
+  validates :last_name, presence: true
+
   def to_s
-    PersonHelper.family_name(self)
+    PersonHelper.family_label(self)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,3 +38,7 @@ en:
   date:
     formats:
       month: "%B %-d"
+
+  misc:
+    family:
+      last_name_default: Leave blank to use "%{name}"

--- a/db/migrate/20161024005052_add_last_name_to_families.rb
+++ b/db/migrate/20161024005052_add_last_name_to_families.rb
@@ -1,0 +1,22 @@
+class AddLastNameToFamilies < ActiveRecord::Migration
+  def change
+    add_column :families, :last_name, :string
+
+    reversible do |dir|
+      Family.reset_column_information
+
+      # Grab family name from a family member
+      Family.all.each do |family|
+        dir.up do
+          last_name = family.people.first.try(:last_name)
+          if last_name.blank?
+            family.last_name = '<UNKNOWN>'
+          else
+            family.last_name = last_name
+          end
+          family.save!
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20161024012140_make_last_name_non_null_on_families.rb
+++ b/db/migrate/20161024012140_make_last_name_non_null_on_families.rb
@@ -1,0 +1,5 @@
+class MakeLastNameNonNullOnFamilies < ActiveRecord::Migration
+  def change
+    change_column_null :families, :last_name, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160928162928) do
+ActiveRecord::Schema.define(version: 20161024012140) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace"
@@ -99,6 +99,7 @@ ActiveRecord::Schema.define(version: 20160928162928) do
     t.string   "country_code", limit: 2
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "last_name",              null: false
   end
 
   create_table "housing_facilities", force: :cascade do |t|

--- a/test/factories/attendee.rb
+++ b/test/factories/attendee.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
     ministry
 
     first_name { Faker::Name.first_name }
-    last_name { Faker::Name.last_name }
+    last_name { Faker::Boolean.boolean(0.9) ? nil : Faker::Name.last_name }
     email { Faker::Internet.email }
     emergency_contact { [true, false].sample }
     phone { Faker::PhoneNumber.international }

--- a/test/factories/child.rb
+++ b/test/factories/child.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     family
 
     first_name { Faker::Name.first_name }
-    last_name { Faker::Name.last_name }
+    last_name { Faker::Boolean.boolean(0.9) ? nil : Faker::Name.last_name }
     birthdate { Faker::Date.between(12.years.ago, 1.years.ago) }
     gender { Person::GENDERS.keys.sample }
   end

--- a/test/factories/family.rb
+++ b/test/factories/family.rb
@@ -2,6 +2,8 @@ using InternationalPhoneNumber
 
 FactoryGirl.define do
   factory :family do
+    last_name { Faker::Name.last_name }
+
     phone { Faker::PhoneNumber.international }
 
     street { Faker::Address.street_name }
@@ -12,25 +14,15 @@ FactoryGirl.define do
 
     factory :family_with_members do
       transient do
-        last_name { Faker::Name.last_name }
         attendee_count { 1 + rand(1) }
         child_count { rand(4) }
       end
 
       after(:create) do |f, params|
-        create_list(
-          :attendee_with_meal_exemptions,
-          params.attendee_count,
-          family: f,
-          last_name: params.last_name
-        )
+        create_list(:attendee_with_meal_exemptions,
+                    params.attendee_count, family: f)
 
-        create_list(
-          :child,
-          params.child_count,
-          family: f,
-          last_name: params.last_name
-        )
+        create_list(:child, params.child_count, family: f)
       end
     end
   end

--- a/test/models/attendee_test.rb
+++ b/test/models/attendee_test.rb
@@ -29,4 +29,23 @@ class AttendeeTest < ActiveSupport::TestCase
     assert_permit @finance_user, @attendee, :destroy
     assert_permit @admin_user, @attendee, :destroy
   end
+
+  test 'must have family' do
+    @attendee = build :attendee, family_id: nil
+    refute @attendee.valid?, 'attendee should be invalid with nil family_id'
+  end
+
+  test 'last_name should default to family name' do
+    @family = create :family, last_name: 'FooBar'
+    @attendee = create :attendee, family_id: @family.id, last_name: nil
+
+    assert_equal 'FooBar', @attendee.last_name
+  end
+
+  test 'family name should not override explicit last_name' do
+    @family = create :family, last_name: 'FooBar'
+    @attendee = create :attendee, family_id: @family.id, last_name: 'OtherName'
+
+    assert_equal 'OtherName', @attendee.last_name
+  end
 end

--- a/test/models/child_test.rb
+++ b/test/models/child_test.rb
@@ -29,4 +29,23 @@ class ChildTest < ActiveSupport::TestCase
     assert_permit @finance_user, @child, :destroy
     assert_permit @admin_user, @child, :destroy
   end
+
+  test 'must have family' do
+    @child = build :child, family_id: nil
+    refute @child.valid?, 'child should be invalid with nil family_id'
+  end
+
+  test 'last_name should default to family name' do
+    @family = create :family, last_name: 'FooBar'
+    @child = create :child, family_id: @family.id, last_name: nil
+
+    assert_equal 'FooBar', @child.last_name
+  end
+
+  test 'family name should not override explicit last_name' do
+    @family = create :family, last_name: 'FooBar'
+    @child = create :child, family_id: @family.id, last_name: 'OtherName'
+
+    assert_equal 'OtherName', @child.last_name
+  end
 end


### PR DESCRIPTION
This PR completes the action items in [PT #128093163: Add Family Model (spouse_ids, address, tel #)](https://www.pivotaltracker.com/story/show/128093163).

The major changes in this PR are:

 * Add `last_name` to `Family` model. Individual attendees and children can override this with their own `last_name` (sometimes family members can have different last names), but if left blank, the family's `last_name` will be used.
 * Make the `family` association mandatory on `Attendee` and `Child`. You can no longer be a lone wolf.
 * Attendees and Children can no longer be created from their own index pages. To create a new person, you have to browse to a Family's `#show` or `#edit` page, and create a new family member via the buttons in the sidebar.

One secondary change:

 * I've updated the `ViewsHelper` module to automatically mix in other helpers, to cut down on copy/paste. 