### PR TITLE
Move staff_number attribute from Person to Family

### DIFF
--- a/app/admin/attendee.rb
+++ b/app/admin/attendee.rb
@@ -7,7 +7,7 @@ ActiveAdmin.register Attendee do
   menu parent: 'People', priority: 2
 
   permit_params(
-    :first_name, :last_name, :email, :emergency_contact, :phone, :staff_number,
+    :first_name, :last_name, :email, :emergency_contact, :phone,
     :student_number, :gender, :department, :family_id, :birthdate, :ministry_id,
     conference_ids: [], course_ids: [], meal_exemptions_attributes: [
       :id, :_destroy, :date, :meal_type
@@ -28,7 +28,6 @@ ActiveAdmin.register Attendee do
     column(:email) { |a| mail_to(a.email) }
     column(:phone) { |a| format_phone(a.phone) }
     column :emergency_contact
-    column(:staff_number) { |a| code a.staff_number }
     column :department
     column :created_at
     column :updated_at

--- a/app/admin/concerns/attendees/form.rb
+++ b/app/admin/concerns/attendees/form.rb
@@ -35,7 +35,6 @@ module Attendees
 
       f.inputs do
         f.input :ministry
-        f.input :staff_number
         f.input :department
       end
 

--- a/app/admin/concerns/attendees/show.rb
+++ b/app/admin/concerns/attendees/show.rb
@@ -34,7 +34,6 @@ module Attendees
           row(:email) { |a| mail_to(a.email) }
           row(:phone) { |a| format_phone(a.phone) }
           row :emergency_contact
-          row(:staff_number) { |a| code a.staff_number }
           row :department
           row :created_at
           row :updated_at

--- a/app/admin/family.rb
+++ b/app/admin/family.rb
@@ -1,12 +1,14 @@
 ActiveAdmin.register Family do
   menu parent: 'People', priority: 1
 
-  permit_params :phone, :street, :city, :state, :zip, :country_code
+  permit_params :staff_number, :phone, :street, :city, :state, :zip,
+                :country_code
 
   index do
     selectable_column
     column :id
     column('Name') { |f| h4 family_name(f) }
+    column(:staff_number) { |f| code f.staff_number }
     column(:phone) { |f| format_phone(f.phone) }
     column :street
     column :city
@@ -21,6 +23,7 @@ ActiveAdmin.register Family do
   show title: ->(f) { PersonHelper.family_name(f) } do
     attributes_table do
       row :id
+      row(:staff_number) { |f| code f.staff_number }
       row(:phone) { |f| format_phone(f.phone) }
       row :street
       row :city
@@ -36,7 +39,10 @@ ActiveAdmin.register Family do
   form title: ->(f) { "Edit #{PersonHelper.family_name(f)}" } do |f|
     f.semantic_errors
 
-    f.inputs :phone
+    f.inputs 'Basic Info' do
+      f.input :phone
+      f.input :staff_number
+    end
 
     f.inputs 'Address' do
       f.input :street

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -3,6 +3,8 @@ class Family < ApplicationRecord
   has_many :attendees
   has_many :children
 
+  validates :staff_number, presence: true
+
   def to_s
     PersonHelper.family_name(self)
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,7 @@ en:
         country_code: Country
         phone: Phone Number
         zip: Zip Code
+        staff_number: Staff ID
       housing_facility:
         country_code: Country
         zip: Zip Code

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,8 +30,8 @@ en:
       family:
         country_code: Country
         phone: Phone Number
-        zip: Zip Code
         staff_number: Staff ID
+        zip: Zip Code
       housing_facility:
         country_code: Country
         zip: Zip Code

--- a/db/migrate/20161025021303_add_staff_number_to_families.rb
+++ b/db/migrate/20161025021303_add_staff_number_to_families.rb
@@ -1,0 +1,21 @@
+class AddStaffNumberToFamilies < ActiveRecord::Migration
+  def change
+    add_column :families, :staff_number, :string
+
+    reversible do |dir|
+      Family.reset_column_information
+
+      dir.up do
+        Family.transaction do
+          # Grab the staff number from a family member
+          Family.all.each do |family|
+            if (staff_number = family.people.first.try(:staff_number))
+              family.staff_number = staff_number
+              family.save!
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20161025021845_remove_staff_number_from_people.rb
+++ b/db/migrate/20161025021845_remove_staff_number_from_people.rb
@@ -1,7 +1,5 @@
 class RemoveStaffNumberFromPeople < ActiveRecord::Migration
   def change
-    remove_column :people, :staff_number, :string
-
     reversible do |dir|
       Person.reset_column_information
 
@@ -17,5 +15,7 @@ class RemoveStaffNumberFromPeople < ActiveRecord::Migration
         end
       end
     end
+
+    remove_column :people, :staff_number, :string
   end
 end

--- a/db/migrate/20161025021845_remove_staff_number_from_people.rb
+++ b/db/migrate/20161025021845_remove_staff_number_from_people.rb
@@ -1,0 +1,21 @@
+class RemoveStaffNumberFromPeople < ActiveRecord::Migration
+  def change
+    remove_column :people, :staff_number, :string
+
+    reversible do |dir|
+      Person.reset_column_information
+
+      dir.down do
+        Person.transaction do
+          # Grab the staff number from the family
+          Person.all.each do |person|
+            if (staff_number = person.family.try(:staff_number))
+              person.staff_number = staff_number
+              person.save!
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20161025022249_make_staff_number_non_null_on_families.rb
+++ b/db/migrate/20161025022249_make_staff_number_non_null_on_families.rb
@@ -1,0 +1,5 @@
+class MakeStaffNumberNonNullOnFamilies < ActiveRecord::Migration
+  def change
+    change_column_null :families, :staff_number, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160928162928) do
+ActiveRecord::Schema.define(version: 20161025022249) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace"
@@ -99,6 +99,7 @@ ActiveRecord::Schema.define(version: 20160928162928) do
     t.string   "country_code", limit: 2
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "staff_number",           null: false
   end
 
   create_table "housing_facilities", force: :cascade do |t|
@@ -137,7 +138,6 @@ ActiveRecord::Schema.define(version: 20160928162928) do
     t.string   "phone"
     t.date     "birthdate"
     t.string   "student_number"
-    t.string   "staff_number"
     t.string   "gender"
     t.string   "department"
     t.integer  "family_id"

--- a/test/factories/attendee.rb
+++ b/test/factories/attendee.rb
@@ -16,7 +16,6 @@ FactoryGirl.define do
       end
     end
     student_number { Faker::Number.number(10) }
-    staff_number { Faker::Number.number(10) }
     gender { Person::GENDERS.keys.sample }
 
     factory :attendee_with_meal_exemptions do

--- a/test/factories/family.rb
+++ b/test/factories/family.rb
@@ -4,6 +4,8 @@ FactoryGirl.define do
   factory :family do
     phone { Faker::PhoneNumber.international }
 
+    staff_number { Faker::Number.number(10) }
+
     street { Faker::Address.street_name }
     city { Faker::Address.city }
     state { Faker::Address.state }

--- a/test/models/family_test.rb
+++ b/test/models/family_test.rb
@@ -29,4 +29,10 @@ class FamilyTest < ActiveSupport::TestCase
     assert_permit @finance_user, @family, :destroy
     assert_permit @admin_user, @family, :destroy
   end
+
+  test 'must have staff_number' do
+    @family = build :family, staff_number: nil
+
+    refute @family.valid?, 'family should be invalid with nil staff_number'
+  end
 end


### PR DESCRIPTION
This PR completes [PT #132622939: Move the Staff Number to a Family, not an individual (and rename to Staff ID)](https://www.pivotaltracker.com/story/show/132622939). Previously, `staff_number` was an optional attribute of `Person`. Now it is a require attribute of `Family`.

This attribute will be presented ("translated") as **Staff ID**, but the attribute will remain as `staff_number`, to avoid confusing it as a foreign key.