### PR TITLE
Meal Exemptions for Children too

### DIFF
--- a/app/admin/child.rb
+++ b/app/admin/child.rb
@@ -1,8 +1,15 @@
 ActiveAdmin.register Child do
+  include Children::Show
+  include Children::Form
+
   menu parent: 'People', priority: 3
 
-  permit_params :first_name, :last_name, :birthdate, :gender, :family,
-                :parent_pickup, :needs_bed, :grade_level, childcare_weeks: []
+  permit_params(
+    :first_name, :last_name, :birthdate, :gender, :family, :parent_pickup,
+    :needs_bed, :grade_level, childcare_weeks: [], meal_exemptions_attributes: [
+      :id, :_destroy, :date, :meal_type
+    ]
+  )
 
   index do
     selectable_column
@@ -20,55 +27,5 @@ ActiveAdmin.register Child do
     column :created_at
     column :updated_at
     actions
-  end
-
-  show do
-    attributes_table do
-      row :id
-      row :first_name
-      row(:last_name) do |c|
-        link_to c.last_name, family_path(c.family) if c.family_id
-      end
-      row(:gender) { |c| gender_name(c.gender) }
-      row :birthdate
-      row('Age', sortable: :birthdate) { |c| age(c.birthdate) }
-      row :grade_level
-      row :childcare_weeks
-      row :parent_pickup
-      row :needs_bed
-      row :created_at
-      row :updated_at
-    end
-    active_admin_comments
-  end
-
-  form do |f|
-    f.semantic_errors
-
-    f.inputs do
-      f.input :first_name
-      f.input :last_name
-      f.input :family
-      f.input :gender, as: :select, collection: gender_select
-      f.input :birthdate, as: :datepicker, datepicker_options:
-        { changeYear: true, changeMonth: true }
-      f.input :grade_level
-      f.input :parent_pickup
-      f.input :needs_bed
-      f.input :childcare_weeks,
-              label: 'Weeks of ChildCare',
-              collection: Childcare::CHILDCARE_WEEKS,
-              multiple: true,
-              hint: 'Please add all weeks needed'
-    end
-    f.inputs 'Assign ChildCare Spaces' do
-      f.input :childcare_id,
-              as: :select,
-              collection: childcare_spaces_select,
-              label: 'Childcare Spaces',
-              prompt: 'please select'
-    end
-
-    f.actions
   end
 end

--- a/app/admin/concerns/attendees/form.rb
+++ b/app/admin/concerns/attendees/form.rb
@@ -1,13 +1,13 @@
 module Attendees
   module Form
-    include FormMealExemptions
+    include People::FormMealExemptions
 
     def self.included(base)
       base.send :form do |f|
         f.semantic_errors
 
         instance_exec(f, &AttendeeInputs)
-        instance_exec(f, &MealExemptionsSubform)
+        instance_exec(f, attendee, &MealExemptionsSubform)
 
         f.actions
       end

--- a/app/admin/concerns/attendees/show.rb
+++ b/app/admin/concerns/attendees/show.rb
@@ -1,6 +1,6 @@
 module Attendees
   module Show
-    include ShowMealExemptions
+    include People::ShowMealExemptions
 
     def self.included(base)
       base.send :show do
@@ -11,7 +11,7 @@ module Attendees
             instance_exec(&ConferencesPanel)
             instance_exec(&CoursesPanel)
             instance_exec(&CostAdjustmentsPanel)
-            instance_exec(&MealExemptionsPanel)
+            instance_exec(attendee, &MealExemptionsPanel)
           end
         end
 

--- a/app/admin/concerns/children/form.rb
+++ b/app/admin/concerns/children/form.rb
@@ -1,0 +1,43 @@
+module Children
+  module Form
+    include People::FormMealExemptions
+
+    def self.included(base)
+      base.send :form do |f|
+        f.semantic_errors
+
+        instance_exec(f, &AttendeeInputs)
+        instance_exec(f, child, &MealExemptionsSubform)
+
+        f.actions
+      end
+    end
+
+    AttendeeInputs = proc do |f|
+      f.inputs do
+        f.input :first_name
+        f.input :last_name
+        f.input :family
+        f.input :gender, as: :select, collection: gender_select
+        f.input :birthdate, as: :datepicker, datepicker_options:
+          { changeYear: true, changeMonth: true }
+        f.input :grade_level
+        f.input :parent_pickup
+        f.input :needs_bed
+        f.input :childcare_weeks,
+                label: 'Weeks of ChildCare',
+                collection: Childcare::CHILDCARE_WEEKS,
+                multiple: true,
+                hint: 'Please add all weeks needed'
+      end
+
+      f.inputs 'Assign ChildCare Spaces' do
+        f.input :childcare_id,
+                as: :select,
+                collection: childcare_spaces_select,
+                label: 'Childcare Spaces',
+                prompt: 'please select'
+      end
+    end
+  end
+end

--- a/app/admin/concerns/children/show.rb
+++ b/app/admin/concerns/children/show.rb
@@ -1,0 +1,40 @@
+module Children
+  module Show
+    include People::ShowMealExemptions
+
+    def self.included(base)
+      base.send :show do
+        columns do
+          column do
+            instance_exec(&AttributesTable)
+          end
+
+          column do
+            instance_exec(child, &MealExemptionsPanel)
+          end
+        end
+
+        active_admin_comments
+      end
+    end
+
+    AttributesTable = proc do
+      attributes_table do
+        row :id
+        row :first_name
+        row(:last_name) do |c|
+          link_to c.last_name, family_path(c.family) if c.family_id
+        end
+        row(:gender) { |c| gender_name(c.gender) }
+        row :birthdate
+        row('Age', sortable: :birthdate) { |c| age(c.birthdate) }
+        row :grade_level
+        row :childcare_weeks
+        row :parent_pickup
+        row :needs_bed
+        row :created_at
+        row :updated_at
+      end
+    end
+  end
+end

--- a/app/admin/concerns/people/form_meal_exemptions.rb
+++ b/app/admin/concerns/people/form_meal_exemptions.rb
@@ -1,8 +1,7 @@
-module Attendees
-  # Defines the view for the Meal Exemptions subform, nested in the Attendee
-  # form.
+module People
+  # Defines the view for the Meal Exemptions subform, nested in a Person's form.
   module FormMealExemptions
-    MealExemptionsSubform = proc do |f|
+    MealExemptionsSubform = proc do |f, person|
       f.inputs 'Meal Exemptions', class: 'meal_exemptions_attributes' do
         # This warning is hidden via Javascript
         h4 class: 'meal_exemptions_attributes__warning' do
@@ -10,7 +9,7 @@ module Attendees
           strong 'deleted'
         end
 
-        # A table of all of the meals this attendee has opted out of. Each row
+        # A table of all of the meals this person has opted out of. Each row
         # represents a day, and each column a single meal exemption in that day
         table do
           thead do
@@ -24,10 +23,10 @@ module Attendees
             next_index = (MealExemption.last.try(:id) || -1) + 1
 
             # Creates a new row for each Date. ex:
-            # |    Date    | Breakfast |   Lunch   |  Dinner  |
-            # | October 20 |   [YES]   |   [YES]   |  [Yes]   |
-            attendee.meal_exemptions.order_by_date.each do |date, types|
-              instance_exec(date, types, next_index, &DateTableRow)
+            # |     Date     |  Breakfast  |   Lunch     |  Dinner   |
+            # |  October 20  |  [EXEMPT]   |  [EXEMPT]  |  [EXEMPT]  |
+            person.meal_exemptions.order_by_date.each do |date, types|
+              instance_exec(person, date, types, next_index, &DateTableRow)
               next_index += 1
             end
 
@@ -41,13 +40,13 @@ module Attendees
       end
     end
 
-    DateTableRow = proc do |date, types, index|
+    DateTableRow = proc do |person, date, types, index|
       tr do
         td { strong l date, format: :month }
 
         MealExemption::TYPES.each do |t|
           td do
-            name = 'attendee[meal_exemptions_attributes]'
+            name = "#{person.class.name.underscore}[meal_exemptions_attributes]"
             record_exists_in_database = types[t].present?
 
             if record_exists_in_database

--- a/app/admin/concerns/people/show_meal_exemptions.rb
+++ b/app/admin/concerns/people/show_meal_exemptions.rb
@@ -1,8 +1,8 @@
-module Attendees
+module People
   module ShowMealExemptions
-    MealExemptionsPanel = proc do
-      panel "Meal Exemptions (#{attendee.meal_exemptions.size})" do
-        if attendee.meal_exemptions.any?
+    MealExemptionsPanel = proc do |person|
+      panel "Meal Exemptions (#{person.meal_exemptions.size})" do
+        if person.meal_exemptions.any?
           table do
             thead do
               tr do
@@ -11,7 +11,7 @@ module Attendees
               end
             end
             tbody do
-              attendee.meal_exemptions.order_by_date.each do |date, types|
+              person.meal_exemptions.order_by_date.each do |date, types|
                 tr do
                   td { strong l date, format: :month }
                   MealExemption::TYPES.each do |t|

--- a/app/assets/javascripts/active_admin.js.coffee
+++ b/app/assets/javascripts/active_admin.js.coffee
@@ -17,5 +17,5 @@
 #  Specific Models
 #  =================================
 #
-#  Attendee ------------------------
-#= require attendee/form
+#  Attendee/Child ------------------
+#= require person/form

--- a/app/assets/javascripts/person/form.coffee
+++ b/app/assets/javascripts/person/form.coffee
@@ -2,18 +2,27 @@ labels =
   yes: 'exempt'
   no:  'accept'
 
+
 $ ->
-  $form = $('#new_attendee, #edit_attendee')
+  setupMealForm('attendee')
+  setupMealForm('child')
+
+
+# @param {string} personType - "attendee" or "child"
+setupMealForm = (personType) ->
+  $form = $("#new_#{personType}, #edit_#{personType}")
   return unless $form.length
 
   $meals = $form.find('.meal_exemptions_attributes')
   invertMealCheckboxes($meals)
   addNewMealButton(
+    personType,
     $meals,
     $meals.find('table tbody'),
     $('#meal_exemptions_attributes__js').data('nextindex')
     $('#meal_exemptions_attributes__js').data('types').split(',')
   )
+
 
 
 # The nested Meal Exemptions form includes a checkbox for each record that,
@@ -54,7 +63,9 @@ updateAddToggle = ($input, exists) ->
 # a new row of records. That is, a new day's worth of meal exemptions. When the
 # user clicks this button, they are prompted to pick a date via the jQuery
 # DatePicker widget and a new row is added for their chosen date.
-addNewMealButton = ($meals, $table, nextIndex, types) ->
+#
+# @param {string} personType - "attendee" or "child"
+addNewMealButton = (personType, $meals, $table, nextIndex, types) ->
   $input = $('<input type="text">').css('display', 'none').datepicker(
     dateFormat: "yy-mm-dd"
     altFormat: "MM d"
@@ -69,7 +80,7 @@ addNewMealButton = ($meals, $table, nextIndex, types) ->
       )
 
     for type in types
-      createNewMealTypeButton($row, type, nextIndex++, date)
+      createNewMealTypeButton(personType, $row, type, nextIndex++, date)
     $table.append($row)
 
   $btn =
@@ -82,14 +93,15 @@ addNewMealButton = ($meals, $table, nextIndex, types) ->
 
 # Creates a new toggle button for a specific Meal Exemption on a specific day.
 #
-# @param {jQuery} $row  - the jQuery row to add the new column to
-# @param {string} type  - the Meal#meal_type of the exemption in this column
+# @param {string} personType - "attendee" or "child"
+# @param {jQuery} $row       - the jQuery row to add the new column to
+# @param {string} type       - the Meal#meal_type of the exemption in this column
 #   (ie: Breakfast, Lunch, or Dinner)
-# @param {number} index - the query string row index of this MealExemption
+# @param {number} index      - the query string row index of this MealExemption
 #   record.
-# @param [Date} date    - the date of the new Meal Exemption record
-createNewMealTypeButton = ($row, type, index, date) ->
-  name = "attendee[meal_exemptions_attributes][#{index}]"
+# @param [Date} date         - the date of the new Meal Exemption record
+createNewMealTypeButton = (personType, $row, type, index, date) ->
+  name = "#{personType}[meal_exemptions_attributes][#{index}]"
   mealExists = true
 
   $destroyToggle =

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -14,8 +14,8 @@
 //  Specific Models
 //  =================================
 
-//  Attendee ------------------------
-@import "attendee/form";
+//  Attendee/Child ------------------
+@import "person/form";
 
 
 // Overriding any non-variable SASS must be done after the fact.

--- a/app/assets/stylesheets/person/form.scss
+++ b/app/assets/stylesheets/person/form.scss
@@ -1,5 +1,7 @@
 #new_attendee,
-#edit_attendee {
+#edit_attendee,
+#new_child,
+#edit_child {
   /**
    * Theses styles are for the custom UI for Attendees' nested MealExemption
    * records.

--- a/app/models/attendee.rb
+++ b/app/models/attendee.rb
@@ -7,7 +7,6 @@ class Attendee < Person
   has_many :conferences, through: :conference_attendances
   has_many :course_attendances
   has_many :courses, through: :course_attendances
-  has_many :meal_exemptions
 
   accepts_nested_attributes_for :meal_exemptions, allow_destroy: true
 end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -1,4 +1,6 @@
 class Child < Person
   belongs_to :family
   belongs_to :childcare
+
+  accepts_nested_attributes_for :meal_exemptions, allow_destroy: true
 end

--- a/app/models/meal_exemption.rb
+++ b/app/models/meal_exemption.rb
@@ -1,9 +1,9 @@
 class MealExemption < ApplicationRecord
   TYPES = %w(Breakfast Lunch Dinner).freeze
 
-  belongs_to :attendee
+  belongs_to :person
 
-  validates :meal_type, uniqueness: { scope: [:attendee_id, :date], message:
+  validates :meal_type, uniqueness: { scope: [:person_id, :date], message:
     'may only have one meal type per day' }
 
   # Creates a Hash table where each key is Date in which there's one or more

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -5,6 +5,7 @@ class Person < ApplicationRecord
   belongs_to :ministry
 
   has_many :cost_adjustments
+  has_many :meal_exemptions
 
   def full_name
     "#{first_name} #{last_name}"

--- a/db/migrate/20161025030516_rename_attendee_id_to_person_id_on_meal_exemptions.rb
+++ b/db/migrate/20161025030516_rename_attendee_id_to_person_id_on_meal_exemptions.rb
@@ -1,0 +1,5 @@
+class RenameAttendeeIdToPersonIdOnMealExemptions < ActiveRecord::Migration
+  def change
+    rename_column :meal_exemptions, :attendee_id, :person_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160928162928) do
+ActiveRecord::Schema.define(version: 20161025030516) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace"
@@ -114,13 +114,13 @@ ActiveRecord::Schema.define(version: 20160928162928) do
 
   create_table "meal_exemptions", force: :cascade do |t|
     t.date     "date"
-    t.integer  "attendee_id"
+    t.integer  "person_id"
     t.string   "meal_type"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "meal_exemptions", ["attendee_id", "date", "meal_type"], name: "index_meal_exemptions_on_attendee_id_and_date_and_meal_type", unique: true
+  add_index "meal_exemptions", ["person_id", "date", "meal_type"], name: "index_meal_exemptions_on_person_id_and_date_and_meal_type", unique: true
 
   create_table "ministries", force: :cascade do |t|
     t.string   "name"

--- a/test/factories/attendee.rb
+++ b/test/factories/attendee.rb
@@ -25,7 +25,7 @@ FactoryGirl.define do
       end
 
       after(:create) do |attendee, params|
-        create_list(:meal_exemption, params.count, attendee: attendee)
+        create_list(:meal_exemption, params.count, person: attendee)
       end
     end
   end

--- a/test/factories/child.rb
+++ b/test/factories/child.rb
@@ -10,5 +10,15 @@ FactoryGirl.define do
       end
     end
     gender { Person::GENDERS.keys.sample }
+
+    factory :child_with_meal_exemptions do
+      transient do
+        count 20
+      end
+
+      after(:create) do |child, params|
+        create_list(:meal_exemption, params.count, person: child)
+      end
+    end
   end
 end

--- a/test/factories/family.rb
+++ b/test/factories/family.rb
@@ -26,7 +26,7 @@ FactoryGirl.define do
         )
 
         create_list(
-          :child,
+          :child_with_meal_exemptions,
           params.child_count,
           family: f,
           last_name: params.last_name

--- a/test/factories/meal_exemption.rb
+++ b/test/factories/meal_exemption.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :meal_exemption do
-    attendee
+    person { build(Faker::Boolean.boolean ? :attendee : :child) }
     date { Faker::Date.between(1.year.ago, 1.year.from_now) }
     meal_type { MealExemption::TYPES.sample }
   end


### PR DESCRIPTION
This PR completes [PT #128092593: As a user, I can edit/create/delete meals for specific days for specific users](https://www.pivotaltracker.com/story/show/128092593). This PR extends the `MealExemption` functionality from just Attendees to Children as well.

The`Attendee` and `Child` models are both subclasses of the `Person` model, so to make this change only required making the meals-related code slightly more generic.