### PR TITLE
Select current Family by default

### DIFF
--- a/app/admin/concerns/attendees/form.rb
+++ b/app/admin/concerns/attendees/form.rb
@@ -15,7 +15,7 @@ module Attendees
 
     AttendeeInputs = proc do |f|
       f.inputs do
-        f.input :family, selected: param_family.try(:id)
+        f.input :family, selected: (f.object.family_id || param_family.try(:id))
       end
 
       f.inputs 'Basic' do

--- a/app/admin/concerns/children/form.rb
+++ b/app/admin/concerns/children/form.rb
@@ -15,7 +15,7 @@ module Children
 
     AttendeeInputs = proc do |f|
       f.inputs do
-        f.input :family, selected: params[:family_id]
+        f.input :family, selected: (f.object.family_id || param_family.try(:id))
       end
 
       f.inputs do


### PR DESCRIPTION
This fixes a small UI bug where the Family select element would be blank, even though an existing record already has a Family associated.