### PR TITLE
Show Cost Adjustments for Children as well

### DIFF
--- a/app/admin/concerns/attendees/show.rb
+++ b/app/admin/concerns/attendees/show.rb
@@ -1,5 +1,6 @@
 module Attendees
   module Show
+    include People::ShowCostAdjustments
     include People::ShowMealExemptions
 
     def self.included(base)
@@ -10,7 +11,7 @@ module Attendees
           column do
             instance_exec(&ConferencesPanel)
             instance_exec(&CoursesPanel)
-            instance_exec(&CostAdjustmentsPanel)
+            instance_exec(attendee, &CostAdjustmentsPanel)
             instance_exec(attendee, &MealExemptionsPanel)
           end
         end
@@ -61,20 +62,6 @@ module Attendees
           ul do
             attendee.courses.each do |c|
               li { link_to(c.name, c) }
-            end
-          end
-        else
-          strong 'None'
-        end
-      end
-    end
-
-    CostAdjustmentsPanel = proc do
-      panel "Cost Adjustments (#{attendee.cost_adjustments.size})" do
-        if attendee.cost_adjustments.any?
-          ul do
-            attendee.cost_adjustments.each do |c|
-              li { link_to(humanized_money_with_symbol(c.price), c) }
             end
           end
         else

--- a/app/admin/concerns/children/show.rb
+++ b/app/admin/concerns/children/show.rb
@@ -1,5 +1,6 @@
 module Children
   module Show
+    include People::ShowCostAdjustments
     include People::ShowMealExemptions
 
     def self.included(base)
@@ -10,6 +11,7 @@ module Children
           end
 
           column do
+            instance_exec(child, &CostAdjustmentsPanel)
             instance_exec(child, &MealExemptionsPanel)
           end
         end

--- a/app/admin/concerns/people/show_cost_adjustments.rb
+++ b/app/admin/concerns/people/show_cost_adjustments.rb
@@ -1,0 +1,17 @@
+module People
+  module ShowCostAdjustments
+    CostAdjustmentsPanel = proc do |person|
+      panel "Cost Adjustments (#{person.cost_adjustments.size})" do
+        if person.cost_adjustments.any?
+          ul do
+            person.cost_adjustments.each do |p|
+              li { link_to(humanized_money_with_symbol(p.price), p) }
+            end
+          end
+        else
+          strong 'None'
+        end
+      end
+    end
+  end
+end

--- a/app/models/attendee.rb
+++ b/app/models/attendee.rb
@@ -1,8 +1,6 @@
 class Attendee < Person
   include FamilyMember
 
-  # TODO: Housing Preferences
-
   belongs_to :family
 
   has_many :conference_attendances


### PR DESCRIPTION
This PR completes the most recent action item for [PT #128092579](https://www.pivotaltracker.com/story/show/128092579). Basically, it just takes the "Cost Adjustments" summary panel on the `attendee#show` page and adds it to `child#show` page as well.