### PR TITLE
Update ministries policy

### DIFF
--- a/app/policies/ministry_policy.rb
+++ b/app/policies/ministry_policy.rb
@@ -1,2 +1,2 @@
-class MinistryPolicy < GeneralPolicy
+class MinistryPolicy < ReadOnlyPolicy
 end

--- a/test/models/ministry_test.rb
+++ b/test/models/ministry_test.rb
@@ -7,8 +7,9 @@ class MinistryTest < ActiveSupport::TestCase
   end
 
   test 'permit create' do
-    assert_permit @general_user, @ministry, :create
-    assert_permit @finance_user, @ministry, :create
+    refute_permit @general_user, @ministry, :create
+    refute_permit @finance_user, @ministry, :create
+
     assert_permit @admin_user, @ministry, :create
   end
 
@@ -19,14 +20,16 @@ class MinistryTest < ActiveSupport::TestCase
   end
 
   test 'permit update' do
-    assert_permit @general_user, @ministry, :update
-    assert_permit @finance_user, @ministry, :update
+    refute_permit @general_user, @ministry, :update
+    refute_permit @finance_user, @ministry, :update
+
     assert_permit @admin_user, @ministry, :update
   end
 
   test 'permit destroy' do
-    assert_permit @general_user, @ministry, :destroy
-    assert_permit @finance_user, @ministry, :destroy
+    refute_permit @general_user, @ministry, :destroy
+    refute_permit @finance_user, @ministry, :destroy
+
     assert_permit @admin_user, @ministry, :destroy
   end
 end


### PR DESCRIPTION
This story completes [PT #133364731: As a general or a finance user, I should only be able to view a Ministry (not edit or delete).  Edit and Delete should only be as an admin user](https://www.pivotaltracker.com/story/show/133364731)