### PR TITLE
family_label: List attendee names aside family name

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,6 +28,5 @@ if Rails.env.test?
   end
 end
 
-if Rails.env.development?
-  YARD::Rake::YardocTask.new
-end
+# Documentation
+YARD::Rake::YardocTask.new if Rails.env.development?

--- a/app/admin/attendee.rb
+++ b/app/admin/attendee.rb
@@ -23,7 +23,8 @@ ActiveAdmin.register Attendee do
     column :id
     column(:student_number) { |a| code a.student_number }
     column :first_name
-    column(:last_name) { |a| link_to last_name_label(a), family_path(a.family) }
+    column :last_name
+    column(:family) { |a| link_to family_label(a.family), family_path(a.family) }
     column :birthdate
     column('Age', sortable: :birthdate) { |a| age(a.birthdate) }
     column(:gender) { |a| gender_name(a.gender) }

--- a/app/admin/child.rb
+++ b/app/admin/child.rb
@@ -19,7 +19,8 @@ ActiveAdmin.register Child do
     selectable_column
     column :id
     column :first_name
-    column(:last_name) { |c| link_to last_name_label(c), family_path(c.family) }
+    column :last_name
+    column(:family) { |c| link_to family_label(c.family), family_path(c.family) }
     column(:gender) { |c| gender_name(c.gender) }
     column :birthdate
     column('Age', sortable: :birthdate) { |c| age(c.birthdate) }

--- a/app/admin/concerns/attendees/show.rb
+++ b/app/admin/concerns/attendees/show.rb
@@ -26,9 +26,8 @@ module Attendees
           row :id
           row(:student_number) { |a| code a.student_number }
           row :first_name
-          row(:last_name) do |a|
-            link_to last_name_label(a), family_path(a.family)
-          end
+          row :last_name
+          row(:family) { |a| link_to family_label(a.family), family_path(a.family) }
           row :birthdate
           row('Age', sortable: :birthdate) { |a| age(a.birthdate) }
           row(:gender) { |a| gender_name(a.gender) }

--- a/app/admin/concerns/children/show.rb
+++ b/app/admin/concerns/children/show.rb
@@ -24,7 +24,8 @@ module Children
       attributes_table do
         row :id
         row :first_name
-        row(:last_name) { |c| link_to last_name_label(c), family_path(c.family) }
+        row :last_name
+        row(:family) { |c| link_to family_label(c.family), family_path(c.family) }
         row(:gender) { |c| gender_name(c.gender) }
         row :birthdate
         row('Age', sortable: :birthdate) { |c| age(c.birthdate) }

--- a/app/admin/family.rb
+++ b/app/admin/family.rb
@@ -7,7 +7,7 @@ ActiveAdmin.register Family do
   index do
     selectable_column
     column :id
-    column :last_name
+    column(:last_name) { |f| family_label(f) }
     column(:staff_number) { |f| code f.staff_number }
     column :street
     column :city
@@ -54,7 +54,7 @@ ActiveAdmin.register Family do
     f.actions
   end
 
-  filter :last_name
+  filter :last_name_or_people_first_name_cont, label: 'Last Name or Family Member Name'
   filter :street
   filter :city
   filter :state

--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -33,7 +33,17 @@ module PersonHelper
   end
 
   def family_label(family)
-    "#{family.last_name} Family ##{family.id}"
+    "#{family.last_name}: #{family_attendees_sentence(family)}"
+  end
+
+  # @return [String] a comma-separated sentence of the attendee's first names
+  #   in the given family
+  def family_attendees_sentence(family)
+    if family.attendees.any?
+      family.attendees.map(&:first_name).to_sentence
+    else
+      'no attendees'
+    end
   end
 
   def last_name_label(person)
@@ -41,7 +51,7 @@ module PersonHelper
     if person.family.nil?
       person.last_name
     elsif person.last_name == person.family.last_name
-      "#{person.last_name} ##{person.family_id}"
+      family_label(person.family)
     else
       "#{person.last_name} (#{family_label(person.family)})"
     end

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -12,6 +12,6 @@ class Family < ApplicationRecord
   end
 
   def audit_name
-    "#{super}: #{last_name}"
+    "#{super}: #{PersonHelper.family_label(self)}"
   end
 end


### PR DESCRIPTION
This PR completes [PT #133051273: Display first names on Family list view](https://www.pivotaltracker.com/story/show/133051273).

There are two main changes:

  1. Family names used to distinguish themselves with their DB ID. ex: Simpson #1234. Now they distinguish themselves by listing the first names of their attendees. ex: Simpson: Marge and Homer.
  2. The `last_name` filter has been replaced with a filter that searches families' first and last names. ex: If you searched for `homer` it would return `The Simpson Family`.