### PR TITLE
Add additional dynamic HousingPreference attributes

### DIFF
--- a/app/admin/concerns/families/form.rb
+++ b/app/admin/concerns/families/form.rb
@@ -1,0 +1,60 @@
+module Families
+  module Form
+    def self.included(base)
+      base.send :form, title: ->(f) { "Edit #{PersonHelper.family_label(f)}" } do |f|
+        f.semantic_errors
+
+        instance_exec(f, &BasicInfoFields)
+        instance_exec(f, &AddressFields)
+        instance_exec(f, &HousingPreferencesFields)
+
+        f.actions
+      end
+    end
+
+    BasicInfoFields = proc do |f|
+      f.inputs 'Basic Info' do
+        f.input :last_name
+        f.input :staff_number
+      end
+    end
+
+    AddressFields = proc do |f|
+      f.inputs 'Address' do
+        f.input :street
+        f.input :city
+        f.input :state
+        f.input :country_code, as: :select, collection: country_select,
+                               include_blank: false
+        f.input :zip
+      end
+    end
+
+    HousingPreferencesFields = proc do |f|
+      for_housing_preference = [
+        :housing_preference,
+        f.object.housing_preference || f.object.build_housing_preference
+      ]
+
+      f.inputs 'Housing Preference', class: 'housing_preference_attributes',
+                                     for: for_housing_preference do |hp|
+        hp.input :housing_type, as: :select, collection: housing_type_select
+
+        dynamic_preference_input(hp, :roommates, input_html: { rows: 4 })
+        dynamic_preference_input(hp, :beds_count)
+        dynamic_preference_input(hp, :single_room)
+
+        dynamic_preference_input(hp, :children_count)
+        dynamic_preference_input(hp, :bedrooms_count)
+        dynamic_preference_input(hp, :other_family)
+        dynamic_preference_input(hp, :accepts_non_air_conditioned)
+
+        dynamic_preference_input(hp, :location1)
+        dynamic_preference_input(hp, :location2)
+        dynamic_preference_input(hp, :location3)
+
+        hp.input :confirmed_at, as: :datepicker
+      end
+    end
+  end
+end

--- a/app/admin/family.rb
+++ b/app/admin/family.rb
@@ -1,13 +1,15 @@
 ActiveAdmin.register Family do
   include Families::Show
+  include Families::Form
 
   menu parent: 'People', priority: 1
 
   permit_params :last_name, :staff_number, :street, :city, :state, :zip,
                 :country_code, housing_preference_attributes: [
-                  :id, :housing_type, :children_count, :bedrooms_count,
-                  :location1, :location2, :location3, :beds_count, :roommates,
-                  :confirmed_at
+                  :id, :housing_type, :roommates, :beds_count, :single_room,
+                  :children_count, :bedrooms_count, :other_family,
+                  :accepts_non_air_conditioned, :location1, :location2,
+                  :location3, :confirmed_at
                 ]
 
   index do
@@ -23,44 +25,6 @@ ActiveAdmin.register Family do
     column :created_at
     column :updated_at
     actions
-  end
-
-  form title: ->(f) { "Edit #{PersonHelper.family_label(f)}" } do |f|
-    f.semantic_errors
-
-    f.inputs 'Basic Info' do
-      f.input :last_name
-      f.input :staff_number
-    end
-
-    f.inputs 'Address' do
-      f.input :street
-      f.input :city
-      f.input :state
-      f.input :country_code, as: :select, collection: country_select,
-                             include_blank: false
-      f.input :zip
-    end
-
-    # Housing Preference sub-form
-    for_housing_preference = [
-      :housing_preference,
-      f.object.housing_preference || f.object.build_housing_preference
-    ]
-    f.inputs 'Housing Preference', class: 'housing_preference_attributes',
-                                   for: for_housing_preference do |hp|
-      hp.input :housing_type, as: :select, collection: housing_type_select
-      hp.input :children_count, wrapper_html: { class: :apartments_only }
-      hp.input :bedrooms_count, wrapper_html: { class: :apartments_only }
-      hp.input :location1
-      hp.input :location2
-      hp.input :location3
-      hp.input :beds_count
-      hp.input :roommates
-      hp.input :confirmed_at, as: :datepicker
-    end
-
-    f.actions
   end
 
   filter :last_name_or_people_first_name_cont, label: 'Last Name or Family Member Name'

--- a/app/assets/javascripts/family/edit.coffee
+++ b/app/assets/javascripts/family/edit.coffee
@@ -2,26 +2,23 @@ $ ->
   $form = $('#edit_family')
   return unless $form.length
 
-  setupApartmentOnlyFields($form.find('.housing_preference_attributes'))
+  setupHousinTypeDynamicFields($form.find('.housing_preference_attributes'))
   setupConfirmedAtToggleButton($form.find('.housing_preference_attributes'))
 
 
-# Some fields are only relevant when the user chooses "Apartment" from the
+# Some fields are only relevant when the user chooses a certain type from the
 # Housing Type select box. We hide/show those choices whenever the select's
 # value is changed.
-setupApartmentOnlyFields = ($form) ->
-  $select = $form.find('select[name="family[housing_preference_attributes][housing_type]"]')
-  $select.on 'change', -> hideApartmentOnlyFields($form, $select.val())
-  hideApartmentOnlyFields($form, $select.val())
+setupHousinTypeDynamicFields = ($form) ->
+  $select = $form.find('select[name$="[housing_type]"]')
+  $select.on 'change', -> showHideDynamicFields($form, $select.val())
+
+  showHideDynamicFields($form, $select.val())
 
 
-hideApartmentOnlyFields = ($form, currentValue) ->
-  apartmentEnumValue = "<%= HousingFacility.housing_types[:apartment] %>"
-
-  if currentValue == apartmentEnumValue
-    $form.find('.apartments_only').show()
-  else
-    $form.find('.apartments_only').hide()
+showHideDynamicFields = ($form, housingType) ->
+  $form.find('.dynamic-field').hide()
+  $form.find(".dynamic-field.for-#{housingType}").show()
 
 
 # One of the Housing Preference fields is "confirmed_at" the date at which the

--- a/app/helpers/housing_helper.rb
+++ b/app/helpers/housing_helper.rb
@@ -27,4 +27,19 @@ module HousingHelper
 
     I18n.t("#{I18N_PREFIX}.housing_types.#{type}")
   end
+
+  # Creates input fields that can by dynamically shown/hidden whenver the user
+  # changes the value of the +housing_type+ select box.
+  #
+  # @se app/assets/javascripts/family/edit.coffee
+  def dynamic_preference_input(form, attribute, opts = {})
+    classes =
+      HousingPreference::HOUSING_TYPE_FIELDS[attribute].
+        map { |t| "for-#{t}" }.join(' ')
+
+    opts[:wrapper_html] ||= {}
+    opts[:wrapper_html][:class] = "dynamic-field #{classes}"
+
+    form.input(attribute, opts)
+  end
 end

--- a/app/models/housing_preference.rb
+++ b/app/models/housing_preference.rb
@@ -1,4 +1,19 @@
 class HousingPreference < ApplicationRecord
+  HOUSING_TYPE_FIELDS = {
+    roommates: [:dormitory].freeze,
+    beds_count: [:dormitory].freeze,
+    single_room: [:dormitory].freeze,
+
+    children_count: [:apartment].freeze,
+    bedrooms_count: [:apartment].freeze,
+    other_family: [:apartment].freeze,
+    accepts_non_air_conditioned: [:apartment].freeze,
+
+    location1: [:apartment, :dormitory].freeze,
+    location2: [:apartment, :dormitory].freeze,
+    location3: [:apartment, :dormitory].freeze
+  }.freeze
+
   enum housing_type: [:dormitory, :apartment, :self_provided]
 
   belongs_to :family

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,13 +57,18 @@ en:
           apartment: Apartment
           self_provided: Self-Provided
       housing_preference:
+        roommates: Preferred Roommates
+        beds_count: "# of Beds"
+        single_room: "Requests a single room"
+
+        children_count: "# of Children"
+        bedrooms_count: "# of Bedrooms"
+        other_family: "Name of a Family They Would be Able to Room with"
+        accepts_non_air_conditioned: "Willing to Accept a non A/C apartment"
+
         location1: "Preferred Location #1"
         location2: "Preferred Location #2"
         location3: "Preferred Location #3"
-        beds_count: "# of Beds"
-        roommates: Preferred Roommates
-        children_count: "# of Children"
-        bedrooms_count: "# of Bedrooms"
         confirmed_at: Confirmed by Admin
 
   active_admin:

--- a/db/migrate/20161123063435_add_columns_to_housing_preferences.rb
+++ b/db/migrate/20161123063435_add_columns_to_housing_preferences.rb
@@ -1,0 +1,7 @@
+class AddColumnsToHousingPreferences < ActiveRecord::Migration
+  def change
+    add_column :housing_preferences, :single_room, :boolean
+    add_column :housing_preferences, :other_family, :string
+    add_column :housing_preferences, :accepts_non_air_conditioned, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161120025232) do
+ActiveRecord::Schema.define(version: 20161123063435) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace"
@@ -119,8 +119,8 @@ ActiveRecord::Schema.define(version: 20161120025232) do
   end
 
   create_table "housing_preferences", force: :cascade do |t|
-    t.integer  "family_id",      null: false
-    t.integer  "housing_type",   null: false
+    t.integer  "family_id",                   null: false
+    t.integer  "housing_type",                null: false
     t.string   "location1"
     t.string   "location2"
     t.string   "location3"
@@ -129,8 +129,11 @@ ActiveRecord::Schema.define(version: 20161120025232) do
     t.date     "confirmed_at"
     t.integer  "children_count"
     t.integer  "bedrooms_count"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.boolean  "single_room"
+    t.string   "other_family"
+    t.boolean  "accepts_non_air_conditioned"
   end
 
   create_table "housing_units", force: :cascade do |t|


### PR DESCRIPTION
This PR completes the story [PT #128092557: As a user, I can edit a Family's preferences for housing (Housing type, Roommates choices and first 3 preferred housing locations, # of beds requested ( if they are single beds? ). If an apt is desired, the # of children coming, # of bedrooms. The date that the administration was notified of this and the date that it was confirmed.](https://www.pivotaltracker.com/story/show/128092557).

Certain attributes of the `HousingPreference` record are only applicable depending on the value of its `housing_type` attribute. The bulk of this code is about hiding/showing these fields (and their inputs in the edit form).