### PR TITLE
module name missing from StubCas call in rake task

### DIFF
--- a/lib/tasks/dev_populate.rake
+++ b/lib/tasks/dev_populate.rake
@@ -13,7 +13,7 @@ namespace :dev do
 
     begin
       User.connection.transaction do
-        StubCas.stub_requests do
+        Support::StubCas.stub_requests do
           create_dummies :user, count: 10
         end
 


### PR DESCRIPTION
I was unable to run rake task due to "uninitialized constant StubCas". Added `Support` namespace in front of `StubCas` to fix.