### PR TITLE
Add model to track childcare envelopes

### DIFF
--- a/app/models/attendee.rb
+++ b/app/models/attendee.rb
@@ -21,8 +21,6 @@ class Attendee < Person
   has_many :conferences, through: :conference_attendances
   has_many :course_attendances, dependent: :destroy
   has_many :courses, through: :course_attendances
-  
-  has_many :childcare_envelopes, dependent: :nullify, foreign_key: 'recipient_id'
 
   accepts_nested_attributes_for :course_attendances, allow_destroy: true
   accepts_nested_attributes_for :meal_exemptions, allow_destroy: true

--- a/app/models/attendee.rb
+++ b/app/models/attendee.rb
@@ -21,6 +21,7 @@ class Attendee < Person
   has_many :conferences, through: :conference_attendances
   has_many :course_attendances, dependent: :destroy
   has_many :courses, through: :course_attendances
+  has_many :childcare_envelopes, dependent: :nullify, foreign_key: 'recipient_id'
 
   accepts_nested_attributes_for :course_attendances, allow_destroy: true
   accepts_nested_attributes_for :meal_exemptions, allow_destroy: true

--- a/app/models/attendee.rb
+++ b/app/models/attendee.rb
@@ -21,6 +21,8 @@ class Attendee < Person
   has_many :conferences, through: :conference_attendances
   has_many :course_attendances, dependent: :destroy
   has_many :courses, through: :course_attendances
+  
+  has_many :childcare_envelopes, dependent: :nullify, foreign_key: 'recipient_id'
 
   accepts_nested_attributes_for :course_attendances, allow_destroy: true
   accepts_nested_attributes_for :meal_exemptions, allow_destroy: true

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -10,7 +10,7 @@ class Child < Person
   belongs_to :childcare
   has_one :primary_person, through: :family, source: :primary_person
   # has_many :conferences, through: :primary_person, source: :conferences
-  has_one :childcare_envelope, dependent: :nullify
+  has_many :childcare_envelopes, dependent: :nullify
 
   scope :in_kidscare, (lambda do
     where(['childcare_weeks is NOT NULL', "childcare_weeks <> ''",

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -10,6 +10,7 @@ class Child < Person
   belongs_to :childcare
   has_one :primary_person, through: :family, source: :primary_person
   # has_many :conferences, through: :primary_person, source: :conferences
+  has_one :childcare_envelope, dependent: :nullify
 
   scope :in_kidscare, (lambda do
     where(['childcare_weeks is NOT NULL', "childcare_weeks <> ''",

--- a/app/models/childcare_envelope.rb
+++ b/app/models/childcare_envelope.rb
@@ -1,0 +1,13 @@
+class ChildcareEnvelope < ActiveRecord::Base
+  belongs_to :child
+  belongs_to :recipient, class_name: 'Attendee'
+
+  validates :envelope_id, :status, presence: true
+  validate :must_belong_to_same_family
+
+  def must_belong_to_same_family
+    if child.family_id != recipient.family_id
+      errors.add(:child, "is not part of the recipients family")
+    end
+  end
+end

--- a/app/models/childcare_envelope.rb
+++ b/app/models/childcare_envelope.rb
@@ -1,4 +1,4 @@
-class ChildcareEnvelope < ActiveRecord::Base
+class ChildcareEnvelope < ApplicationRecord
   belongs_to :child
   belongs_to :recipient, class_name: 'Attendee'
 

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -7,6 +7,7 @@ class Family < ApplicationRecord
   has_many :attendees, dependent: :destroy
   has_many :children, dependent: :destroy
   has_many :payments, dependent: :destroy
+  has_many :childcare_envelopes, through: :primary_person
   has_one :housing_preference, autosave: true, dependent: :destroy,
                                inverse_of: :family
   has_one :chargeable_staff_number, primary_key: :staff_number,

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -7,7 +7,7 @@ class Family < ApplicationRecord
   has_many :attendees, dependent: :destroy
   has_many :children, dependent: :destroy
   has_many :payments, dependent: :destroy
-  has_many :childcare_envelopes, through: :primary_person
+  has_many :childcare_envelopes, through: :children
   has_one :housing_preference, autosave: true, dependent: :destroy,
                                inverse_of: :family
   has_one :chargeable_staff_number, primary_key: :staff_number,

--- a/db/migrate/20181221001726_create_childcare_envelopes.rb
+++ b/db/migrate/20181221001726_create_childcare_envelopes.rb
@@ -1,0 +1,14 @@
+class CreateChildcareEnvelopes < ActiveRecord::Migration
+  def change
+    create_table :childcare_envelopes do |t|
+      t.string :envelope_id, index: true, null: false
+      t.string :status, null: false
+
+      t.timestamps null: false
+    end
+    add_column :childcare_envelopes, :recipient_id, :integer, null: false
+    add_foreign_key :childcare_envelopes, :people, column: :recipient_id
+    add_column :childcare_envelopes, :child_id, :integer, null: false
+    add_foreign_key :childcare_envelopes, :people, column: :child_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170710190755) do
+ActiveRecord::Schema.define(version: 20181221001726) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,17 @@ ActiveRecord::Schema.define(version: 20170710190755) do
   end
 
   add_index "chargeable_staff_numbers", ["staff_number"], name: "index_chargeable_staff_numbers_on_staff_number", using: :btree
+
+  create_table "childcare_envelopes", force: :cascade do |t|
+    t.string   "envelope_id",  null: false
+    t.string   "status",       null: false
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+    t.integer  "recipient_id", null: false
+    t.integer  "child_id",     null: false
+  end
+
+  add_index "childcare_envelopes", ["envelope_id"], name: "index_childcare_envelopes_on_envelope_id", using: :btree
 
   create_table "childcares", force: :cascade do |t|
     t.string   "name"
@@ -388,5 +399,7 @@ ActiveRecord::Schema.define(version: 20170710190755) do
 
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
 
+  add_foreign_key "childcare_envelopes", "people", column: "child_id"
+  add_foreign_key "childcare_envelopes", "people", column: "recipient_id"
   add_foreign_key "people", "seminaries"
 end

--- a/test/factories/childcare_envelope.rb
+++ b/test/factories/childcare_envelope.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :childcare_envelope do
+    envelope_id { SecureRandom.uuid }
+    status      { ['sent', 'delivered', 'completed', 'declined', 'voided'].sample }
+    child
+    association :recipient, factory: :attendee
+
+    after(:build) { |ce| ce.recipient.family = ce.child.family }
+  end
+end

--- a/test/models/childcare_envelope_test.rb
+++ b/test/models/childcare_envelope_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class ChildcareEnvelopeTest < ModelTestCase
+
+  def setup
+    @attendee = build :attendee, family_id: 1
+    @child = build :child, family_id: 1
+    @subject = ChildcareEnvelope.new(envelope_id: "1234", status: "sent", recipient: @attendee, child: @child)
+  end
+
+  test 'valid childcare envelope' do
+    assert @subject.valid?
+  end
+
+  test 'invalid without a docusign envelope id' do
+    @subject.envelope_id = nil
+
+    refute @subject.valid?
+    assert_not_nil @subject.errors[:envelope_id], "can't be blank"
+  end
+
+  test 'invalid without a status' do
+    @subject.status = nil
+
+    refute @subject.valid?
+    assert_not_nil @subject.errors[:status], "can't be blank"
+  end
+
+  test 'invalid if recipient and child do not belong to the same family' do
+    @child.family_id = 2
+
+    refute @subject.valid?
+    assert_not_nil @subject.errors[:child], 'is not part of the recipients family'
+  end
+end


### PR DESCRIPTION
ChildcareEnvelopes table was added to be used to keep track of DocuSign envelope_id, its initial status, the recipient to whom we sent the envelope, the child for which the envelope was created for and the initial timestamp.

