### PR TITLE
Add precheck email token

### DIFF
--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -8,10 +8,13 @@ class Family < ApplicationRecord
   has_many :children, dependent: :destroy
   has_many :payments, dependent: :destroy
   has_many :childcare_envelopes, through: :children
+
+  has_one :precheck_email_token, dependent: :destroy
   has_one :housing_preference, autosave: true, dependent: :destroy,
                                inverse_of: :family
   has_one :chargeable_staff_number, primary_key: :staff_number,
                                     foreign_key: :staff_number
+
   belongs_to :primary_person, class_name: 'Attendee',
                               foreign_key: :primary_person_id
 

--- a/app/models/precheck_email_token.rb
+++ b/app/models/precheck_email_token.rb
@@ -1,0 +1,18 @@
+class PrecheckEmailToken < ApplicationRecord
+  self.primary_key = 'token'
+
+  belongs_to :family
+
+  validates :token, presence: true, uniqueness: true
+  validates :family, presence: true, uniqueness: { message: 'Family already has a precheck email token' }
+
+  after_initialize do
+    self.token = generate_token if token.blank?
+  end
+
+  private
+
+  def generate_token
+    SecureRandom.urlsafe_base64(16)
+  end
+end

--- a/db/migrate/20190108004927_create_precheck_email_tokens.rb
+++ b/db/migrate/20190108004927_create_precheck_email_tokens.rb
@@ -1,0 +1,9 @@
+class CreatePrecheckEmailTokens < ActiveRecord::Migration
+  def change
+    create_table :precheck_email_tokens, id: false do |t|
+      t.string :token, index: { unique: true }, null: false
+      t.references :family, index: { unique: true }, foreign_key: true, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181221001726) do
+ActiveRecord::Schema.define(version: 20190108004927) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -304,6 +304,16 @@ ActiveRecord::Schema.define(version: 20181221001726) do
   add_index "people", ["student_number"], name: "index_people_on_student_number", using: :btree
   add_index "people", ["type"], name: "index_people_on_type", using: :btree
 
+  create_table "precheck_email_tokens", id: false, force: :cascade do |t|
+    t.string   "token",      null: false
+    t.integer  "family_id",  null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "precheck_email_tokens", ["family_id"], name: "index_precheck_email_tokens_on_family_id", unique: true, using: :btree
+  add_index "precheck_email_tokens", ["token"], name: "index_precheck_email_tokens_on_token", unique: true, using: :btree
+
   create_table "reports", force: :cascade do |t|
     t.string   "category",                       null: false
     t.string   "name",                           null: false
@@ -402,4 +412,5 @@ ActiveRecord::Schema.define(version: 20181221001726) do
   add_foreign_key "childcare_envelopes", "people", column: "child_id"
   add_foreign_key "childcare_envelopes", "people", column: "recipient_id"
   add_foreign_key "people", "seminaries"
+  add_foreign_key "precheck_email_tokens", "families"
 end

--- a/test/factories/precheck_email_token.rb
+++ b/test/factories/precheck_email_token.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :precheck_email_token do
+    family
+  end
+end

--- a/test/models/precheck_email_token_test.rb
+++ b/test/models/precheck_email_token_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class PrecheckEmailTokenTest < ModelTestCase
+  setup do
+    @family = build(:family)
+  end
+
+  test 'valid precheck email token requires a family' do
+    @subject = PrecheckEmailToken.new(family: @family)
+    assert @subject.valid?
+  end
+
+  test 'auto generates a token on initialization' do
+    @subject = PrecheckEmailToken.new
+    assert @subject.token
+  end
+
+  test 'is invalid without a family' do
+    @subject = PrecheckEmailToken.new
+    refute @subject.valid?
+    assert_equal [:family], @subject.errors.keys
+  end
+
+  test 'a family can only have one precheck email token at a time' do
+    create(:precheck_email_token, family: @family)
+
+    @subject = PrecheckEmailToken.new(family: @family)
+    refute @subject.valid?
+    assert_equal ["Family already has a precheck email token"], @subject.errors.messages[:family]
+  end
+end


### PR DESCRIPTION
When sending a precheck email to a family, we generate a unique token to identify the family when the link on the email is clicked.