### PR TITLE
Add precheck email controller

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -11,5 +11,6 @@
  * file per style scope.
  *
  *= require ./active_admin
+ *= require ./precheck
  *= require ./login
  */

--- a/app/assets/stylesheets/precheck.scss
+++ b/app/assets/stylesheets/precheck.scss
@@ -1,0 +1,92 @@
+.precheck-container {
+  position: relative;
+  width: 100%;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 20px;
+  box-sizing: border-box; 
+
+  /* For devices larger than 400px */
+  @media (min-width: 400px) {
+    .precheck-container {
+      width: 85%;
+      padding: 0; }
+  }
+
+  p {
+    font-size: 1.3rem;
+    margin-bottom: 0;
+  }
+
+  .centered {
+    text-align: center;
+  }
+
+  .logo {
+    display: inherit;
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: 2rem;
+    width: 200px    
+  }
+
+  .greeting {
+    margin-top: 40px;
+  }
+
+  textarea {
+    width: calc(100% - 20px);
+    margin-top: 1rem;
+    font-size: 1.3rem;
+  }
+
+  textarea::placeholder {
+    opacity: 0.6;
+  }
+
+  .btn {
+    margin-top: 20px;
+    width: 200px;
+    height: 50px;
+    font-size: 1rem;
+  }
+
+  .btn-confirm {
+    background-image: linear-gradient(180deg, #06b0cc, #005765);
+    border-color: #005765;
+    background-color: #005765;
+  }
+
+  .btn-confirm:hover {
+    background-color: #005765;
+    background-image: linear-gradient(180deg, #30c9e0, #006e80) !important;
+  }
+
+  .btn-cancel {
+    background-image: linear-gradient(180deg, #f71c1c, #6f0000);
+    border-color: #6f0000;
+    background-color: #a50d0d;
+  }
+
+  .btn-cancel:hover {
+    background-color: #005765;
+    background-image: linear-gradient(180deg, #fd3030, #9e0303) !important;
+  }
+
+  .error-logo {
+    display: inherit;
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: 5rem;
+    width: 300px
+  }
+
+  .error-title {
+    margin-top: 40px;
+    text-decoration: underline;
+  }
+}
+
+
+
+

--- a/app/controllers/precheck_emails_controller.rb
+++ b/app/controllers/precheck_emails_controller.rb
@@ -1,11 +1,25 @@
 class PrecheckEmailsController < ApplicationController
-  before_action :find_token, only: %i[new]
+  before_action :find_token, only: %i[new reject]
 
   def new
     render 'error' and return unless @token
 
     @family = @token.family
   end
+
+  def reject
+    render 'error' and return unless @token
+
+    family = @token.family
+    message = params['message']
+
+    if PrecheckMailer.changes_requested(family, message).deliver_now
+      @token.delete
+    end
+    redirect_to precheck_email_rejected_path
+  end
+
+  def rejected; end
 
   private
 

--- a/app/controllers/precheck_emails_controller.rb
+++ b/app/controllers/precheck_emails_controller.rb
@@ -1,11 +1,26 @@
+# TODO: Mark as pre checked complete on confirm action
+
 class PrecheckEmailsController < ApplicationController
-  before_action :find_token, only: %i[new reject]
+  before_action :find_token, only: %i[new confirm reject]
 
   def new
     render 'error' and return unless @token
 
     @family = @token.family
   end
+
+  def confirm
+    render 'error' and return unless @token
+
+    @family = @token.family
+    # TODO: Mark as pre checked complete
+    if PrecheckMailer.precheck_completed(@family).deliver_now
+      @token.delete
+    end
+    redirect_to precheck_email_confirmed_path
+  end
+
+  def confirmed; end
 
   def reject
     render 'error' and return unless @token

--- a/app/controllers/precheck_emails_controller.rb
+++ b/app/controllers/precheck_emails_controller.rb
@@ -1,0 +1,17 @@
+class PrecheckEmailsController < ApplicationController
+  before_action :find_token, only: %i[new]
+
+  def new
+    render 'error' and return unless @token
+
+    @family = @token.family
+  end
+
+  private
+
+  def find_token
+    return unless params['auth_token']
+
+    @token = PrecheckEmailToken.where(token: params['auth_token']).first
+  end
+end

--- a/app/views/precheck_emails/confirmed.html.erb
+++ b/app/views/precheck_emails/confirmed.html.erb
@@ -1,0 +1,7 @@
+<div class='precheck-container'>
+  <%= image_tag(image_url('logo.png', host: ActionController::Base.asset_host), class: 'logo') %>
+
+  <h1 class="greeting centered">Congratulations, your precheck is completed!</h1>
+  <p class="centered">Your family have been successfully confirmed as prechecked for CRU conf 2019, and you should receive a confirmation email shortly with all the details for the event.</p>
+</div>
+

--- a/app/views/precheck_emails/error.html.erb
+++ b/app/views/precheck_emails/error.html.erb
@@ -1,0 +1,12 @@
+<div class='precheck-container'>
+  <%= image_tag(image_url('logo.png', host: ActionController::Base.asset_host), class: 'error-logo') %>
+
+  <h1 class="error-title centered">There was an error with your request</h1>
+  <div class="error-message centered">
+    <p>Your family has already been confirmed for precheck</p> 
+    <p>or a change request has been made and is pending review.</p>
+    <br>
+    <br>
+    <p>For further assistance, please contact our support team.</p>
+  </div>
+</div>

--- a/app/views/precheck_emails/new.html.erb
+++ b/app/views/precheck_emails/new.html.erb
@@ -1,0 +1,17 @@
+<div class='precheck-container'>
+  <%= image_tag(image_url('logo.png', host: ActionController::Base.asset_host), class: 'logo') %>
+
+  <h1 class="greeting">Hello <%= @family.last_name %> family!</h1>
+  <p>If your personal details and your conference cost breakdown are correct, please click below to confirm your precheck.</p>
+  <%= button_to "Confirm Precheck", precheck_email_confirm_path(auth_token: @token), class: "btn btn-confirm" %>
+  <br>
+  <br>
+  <p>Otherwise, if you would like to request a change or if there is a mistake on your profile or the charges, please add a message below and click the Request Changes button to notify us.</p>
+
+  <%= form_tag precheck_email_reject_path(auth_token: @token) do %>
+    <%= text_area_tag(:message,'',rows: 10, placeholder: "Include your change request or message on this box") %>
+    <br>
+    <%= submit_tag("Request Changes", class: "btn btn-cancel") %>
+  <% end %>
+
+</div>

--- a/app/views/precheck_emails/new.html.erb
+++ b/app/views/precheck_emails/new.html.erb
@@ -3,7 +3,7 @@
 
   <h1 class="greeting">Hello <%= @family.last_name %> family!</h1>
   <p>If your personal details and your conference cost breakdown are correct, please click below to confirm your precheck.</p>
-  <%= button_to "Confirm Precheck", precheck_email_confirm_path(auth_token: @token), class: "btn btn-confirm" %>
+  <%= button_to "Confirm Precheck", precheck_email_confirm_path(auth_token: @token), class: "btn btn-confirm", data: { confirm: "Are you sure you reviewed your details and want to confirm your precheck?", disable_with: "Confirming" } %>
   <br>
   <br>
   <p>Otherwise, if you would like to request a change or if there is a mistake on your profile or the charges, please add a message below and click the Request Changes button to notify us.</p>
@@ -11,7 +11,7 @@
   <%= form_tag precheck_email_reject_path(auth_token: @token) do %>
     <%= text_area_tag(:message,'',rows: 10, placeholder: "Include your change request or message on this box") %>
     <br>
-    <%= submit_tag("Request Changes", class: "btn btn-cancel") %>
+    <%= submit_tag("Request Changes", class: "btn btn-cancel", data: { confirm: "Are you sure you want to request changes?", disable_with: "Processing" }) %>
   <% end %>
 
 </div>

--- a/app/views/precheck_emails/rejected.html.erb
+++ b/app/views/precheck_emails/rejected.html.erb
@@ -1,0 +1,6 @@
+<div class='precheck-container'>
+  <%= image_tag(image_url('logo.png', host: ActionController::Base.asset_host), class: 'logo') %>
+
+  <h1 class="greeting centered">Precheck review request received</h1>
+  <p class="centered">The conference team have been notified of your request and will contact you as soon as possible.</p>
+</div>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,6 +31,8 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
+
   # Randomize the order test cases are executed.
   config.active_support.test_order = :random
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,6 @@ Rails.application.routes.draw do
   get '/housing_units_list', to: 'housing_units_list#index'
   get '/unauthorized', to: 'login#unauthorized', as: :unauthorized_login
   get '/monitors/lb', to: 'monitors#service_online'
+
+  get  '/precheck_email',           to: 'precheck_emails#new'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,6 @@ Rails.application.routes.draw do
   get '/monitors/lb', to: 'monitors#service_online'
 
   get  '/precheck_email',           to: 'precheck_emails#new'
+  get  '/precheck_email/rejected',  to: 'precheck_emails#rejected', as: :precheck_email_rejected
+  post '/precheck_email/reject',    to: 'precheck_emails#reject', as: :precheck_email_reject
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
   get '/monitors/lb', to: 'monitors#service_online'
 
   get  '/precheck_email',           to: 'precheck_emails#new'
+  get  '/precheck_email/confirmed', to: 'precheck_emails#confirmed', as: :precheck_email_confirmed
   get  '/precheck_email/rejected',  to: 'precheck_emails#rejected', as: :precheck_email_rejected
+  post '/precheck_email/confirm',   to: 'precheck_emails#confirm', as: :precheck_email_confirm
   post '/precheck_email/reject',    to: 'precheck_emails#reject', as: :precheck_email_reject
 end

--- a/test/controllers/precheck_emails_controller_test.rb
+++ b/test/controllers/precheck_emails_controller_test.rb
@@ -23,4 +23,31 @@ class PrecheckEmailsControllerTest < ControllerTestCase
     assert_template :new
     assigns(:family)
   end
+
+  test 'reject action without an auth param gets error page' do
+    post :reject
+    assert_response :success
+    assert_template :error
+  end
+
+  test 'reject action with an invalid auth token get error page' do
+    post :reject, auth_token: "sdfsdf"
+    assert_response :success
+    assert_template :error
+  end
+
+  test 'reject action with a valid token sends change request email and deletes token' do
+    token = create(:precheck_email_token)
+    
+    assert_difference('PrecheckEmailToken.count', -1) do
+      assert_emails 1 do
+        post :reject, auth_token: token.token, message: "My name is misspelled"
+      end
+    end
+    
+    assigns(:family)
+    last_email = ActionMailer::Base.deliveries.last
+    assert_equal "Cru19 Precheck Modification Request", last_email.subject
+    assert_redirected_to precheck_email_rejected_path
+  end
 end

--- a/test/controllers/precheck_emails_controller_test.rb
+++ b/test/controllers/precheck_emails_controller_test.rb
@@ -3,6 +3,12 @@ require 'test_helper'
 class PrecheckEmailsControllerTest < ControllerTestCase
   include ActionMailer::TestHelper
 
+  setup do
+    create(:user_variable, short_name: :CONFID, value_type: 'string', value: 'MyConfName')
+    create(:user_variable, short_name: :CONFEMAIL, value_type: 'string', value: 'my_conf_email@example.org')
+    create(:user_variable, short_name: :SUPPORTEMAIL, value_type: 'string', value: 'support@example.org')
+  end
+
   test 'new action without an auth param gets error page' do
     get :new
     assert_response :success
@@ -47,7 +53,7 @@ class PrecheckEmailsControllerTest < ControllerTestCase
     
     assigns(:family)
     last_email = ActionMailer::Base.deliveries.last
-    assert_equal "Cru19 Precheck Modification Request", last_email.subject
+    assert_equal "MyConfName - Precheck Modification Request", last_email.subject
     assert_redirected_to precheck_email_rejected_path
   end
 
@@ -74,7 +80,7 @@ class PrecheckEmailsControllerTest < ControllerTestCase
     
     assigns(:family)
     last_email = ActionMailer::Base.deliveries.last
-    assert_equal "Cru19 - Precheck Completed", last_email.subject
+    assert_equal "MyConfName - Precheck Completed", last_email.subject
     assert_redirected_to precheck_email_confirmed_path
   end
 end

--- a/test/controllers/precheck_emails_controller_test.rb
+++ b/test/controllers/precheck_emails_controller_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class PrecheckEmailsControllerTest < ControllerTestCase
+  include ActionMailer::TestHelper
+
+  test 'new action without an auth param gets error page' do
+    get :new
+    assert_response :success
+    assert_template :error
+  end
+
+  test 'new action with an invalid auth token gets error page' do
+    get :new, auth_token: "sdfsdf"
+    assert_response :success
+    assert_template :error
+  end
+
+  test 'new action with a valid auth token' do
+    token = create(:precheck_email_token)
+    get :new, auth_token: token.token
+
+    assert_response :success
+    assert_template :new
+    assigns(:family)
+  end
+end

--- a/test/mailers/precheck_mailer_test.rb
+++ b/test/mailers/precheck_mailer_test.rb
@@ -3,10 +3,10 @@ require 'test_helper'
 class PrecheckMailerTest < MailTestCase
 
   setup do
-   create(:user_variable, short_name: :CONFID, value_type: 'string', value: 'MyConfName')
-   create(:user_variable, short_name: :CONFEMAIL, value_type: 'string', value: 'my_conf_email@example.org')
-   create(:user_variable, short_name: :SUPPORTEMAIL, value_type: 'string', value: 'support@example.org')
-   @family = build(:family)
+    create(:user_variable, short_name: :CONFID, value_type: 'string', value: 'MyConfName')
+    create(:user_variable, short_name: :CONFEMAIL, value_type: 'string', value: 'my_conf_email@example.org')
+    create(:user_variable, short_name: :SUPPORTEMAIL, value_type: 'string', value: 'support@example.org')
+    @family = build(:family)
   end
 
   test '#precheck_completed' do
@@ -28,16 +28,27 @@ class PrecheckMailerTest < MailTestCase
     assert_match "<p>my name was mispelled</p>", email.body.to_s
   end
 
-  # test '#confirm_charges' do
-  #   @family.save
-  #   email = PrecheckMailer.confirm_charges(@family).deliver_now
-  #   assert_not ActionMailer::Base.deliveries.empty?
+  test '#confirm_charges creates a auth token for the family' do
+    @family.save
+    assert_difference('PrecheckEmailToken.count', +1) do
+      email = PrecheckMailer.confirm_charges(@family).deliver_now
 
-  #   assert_equal ['my_conf_email@example.org'], email.from
-  #   assert_equal ['josh.starcher@cru.org'], email.to
-  #   assert_equal 'MyConfName - Precheck Confirmation Email', email.subject
-  # end
+      assert_not ActionMailer::Base.deliveries.empty?
+  
+      assert_equal ['my_conf_email@example.org'], email.from
+      assert_equal ['josh.starcher@cru.org'], email.to
+      assert_equal 'MyConfName - Precheck Confirmation Email', email.subject
+    end
+  end
 
-  # test '#confirm_charges with an existing token regenerates it' do
-  # end
+  test '#confirm_charges with an existing token overwites it with a new one' do
+    @family.save
+    existing_token = create(:precheck_email_token, family: @family)
+
+    assert_no_difference('PrecheckEmailToken.count') do
+      email = PrecheckMailer.confirm_charges(@family).deliver_now
+
+      assert_no_match existing_token.token, email.body.to_s
+    end
+  end
 end


### PR DESCRIPTION
**Notice:** PR expects https://github.com/CruGlobal/staff-conf-onsite/pull/92 and https://github.com/CruGlobal/staff-conf-onsite/pull/93 to be merged first!

* Add routes and controller to handle precheck email links: Actions ensure token exists before proceeding. In case of token not existing, we render a friendlier error page.
The new action allows user to click to confirm precheck, or alternatively request modifications, which triggers an email to staff.
* Once a family member clicks on confirm or request changes, the token is invalidated, to avoid the possibility of changing from confirmed to request changes later on.