### PR TITLE
Auto set family spouses

### DIFF
--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -70,7 +70,7 @@ module PersonHelper
   #   in the given family
   def family_attendees_sentence(family)
     if family.attendees.any?
-      family.attendees.map(&:first_name).to_sentence
+      family.attendees.map(&:first_name).sort.to_sentence
     else
       'no attendees'
     end

--- a/app/models/attendee.rb
+++ b/app/models/attendee.rb
@@ -13,6 +13,8 @@ class Attendee < Person
 
   after_initialize :set_default_seminary
   before_save :touch_conference_status_changed, if: :conference_status_changed?
+  after_create  -> { family.update_spouses }
+  after_destroy -> { family.update_spouses }
 
   belongs_to :family
   belongs_to :seminary

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -86,6 +86,15 @@ class Family < ApplicationRecord
     attendees.any? { |p| p.email.present? }
   end
 
+  def update_spouses
+    if attendees.reload.size == 2
+      attendees.first.update!(spouse: attendees.second)
+      attendees.second.update!(spouse: attendees.first)
+    else
+      attendees.each { |attendee| attendee.update!(spouse: nil) }
+    end
+  end
+
   private
 
   def remove_blank_housing_preference

--- a/app/services/import/create_new_people_records.rb
+++ b/app/services/import/create_new_people_records.rb
@@ -19,7 +19,6 @@ class Import::CreateNewPeopleRecords < UploadService # rubocop:disable Metrics/C
   def call
     ApplicationRecord.transaction do
       people = create_people
-      assign_spouses(people)
       persist_records!(families.values, people)
     end
   rescue PersonExistsError
@@ -141,26 +140,6 @@ class Import::CreateNewPeopleRecords < UploadService # rubocop:disable Metrics/C
 
   def ministries
     @ministries ||= Ministry.all
-  end
-
-  def assign_spouses(people)
-    family_records = families.values.map(&:record)
-    people_records = people.map(&:record)
-
-    family_records.each do |family_record|
-      spouses = select_attendees_in_family(family_record, people_records)
-
-      next unless spouses.size == 2
-
-      spouses.first.spouse = spouses.second
-      spouses.second.spouse = spouses.first
-    end
-  end
-
-  def select_attendees_in_family(family_record, people_records)
-    people_records.select do |person_record|
-      person_record.is_a?(Attendee) && person_record.family == family_record
-    end
   end
 
   def persist_records!(families, people)

--- a/lib/tasks/tests.rake
+++ b/lib/tasks/tests.rake
@@ -3,13 +3,24 @@
   Rake.application.instance_variable_get('@tasks').delete(t)
 end
 
-desc 'Run the entire suit of tests and linters'
-task :default do
-  border = '=' * 80
-  tasks = %w[rubocop reek coffeelint bundle:audit test]
+border = '=' * 80
+code_analysis_tasks = %w[rubocop reek coffeelint bundle:audit]
 
-  puts "The following Rake tasks will be run: #{tasks.to_sentence}"
-  tasks.each do |task|
+desc 'Run all tests and code analysis'
+task :default do
+  all_tasks = code_analysis_tasks + %w[test]
+  puts "The following Rake tasks will be run: #{all_tasks.to_sentence}"
+  all_tasks.each do |task|
+    puts "\n#{border}\nRunning `rake #{task}`\n#{border}"
+    Rake::Task[task].invoke
+  end
+  puts 'Success.'
+end
+
+desc 'Run code analysis'
+task :analysis do
+  puts "The following Rake tasks will be run: #{code_analysis_tasks.to_sentence}"
+  code_analysis_tasks.each do |task|
     puts "\n#{border}\nRunning `rake #{task}`\n#{border}"
     Rake::Task[task].invoke
   end
@@ -20,7 +31,7 @@ Rake::TestTask.new('test:units') do |t|
   t.test_files = FileList['test/**/*_test.rb'].exclude(
     'test/integration/**/*_test.rb'
   )
-  t.description = 'Run quicker unit tests'
+  t.description = 'Run quicker unit tests (all tests except integration tests)'
   t.libs << 'test'
   t.warning = false
   t.verbose = true

--- a/test/models/family_test.rb
+++ b/test/models/family_test.rb
@@ -66,4 +66,40 @@ class FamilyTest < ModelTestCase
 
     assert_equal [approved_family], Family.precheck_approved.to_a
   end
+
+  test '#update_spouses updates two attendees' do
+    attendee_one = create :attendee, family: @family
+    assert_nil attendee_one.reload.spouse
+    attendee_two = create :attendee, family: @family
+    assert_equal attendee_one.reload.spouse, attendee_two
+    assert_equal attendee_two.reload.spouse, attendee_one
+  end
+
+  test '#update_spouses sets spouse to nil if there are more than two attendees' do
+    attendee_one = create :attendee, family: @family
+    attendee_two = create :attendee, family: @family
+    assert_equal attendee_one.reload.spouse, attendee_two
+    attendee_three = create :attendee, family: @family
+    assert_nil attendee_one.reload.spouse
+    assert_nil attendee_two.reload.spouse
+    assert_nil attendee_three.reload.spouse
+  end
+
+  test '#update_spouses sets spouse to nil if there are less than two attendees' do
+    attendee_one = create :attendee, family: @family
+    attendee_two = create :attendee, family: @family
+    assert_equal attendee_one.reload.spouse, attendee_two
+    attendee_two.destroy
+    assert_nil attendee_one.reload.spouse
+  end
+
+  test '#update_spouses ignores children' do
+    attendee_one = create :attendee, family: @family
+    child_one = create :child, family: @family
+    assert_nil attendee_one.reload.spouse
+    attendee_two = create :attendee, family: @family
+    assert_equal attendee_one.reload.spouse, attendee_two
+    child_one.destroy
+    assert_equal attendee_one.reload.spouse, attendee_two
+  end
 end


### PR DESCRIPTION
Spouse should be set when creating records manually and when importing
families.