### PR TITLE
Send precheck email immediately on status change

### DIFF
--- a/app/services/updated_family_precheck_status_service.rb
+++ b/app/services/updated_family_precheck_status_service.rb
@@ -9,7 +9,9 @@ class UpdatedFamilyPrecheckStatusService < ApplicationService
 
   private
 
-  def pending_approval; end
+  def pending_approval
+    PrecheckMailer.confirm_charges(family).deliver_now
+  end
 
   def changes_requested
     PrecheckMailer.changes_requested(family, message).deliver_now

--- a/test/services/updated_family_precheck_status_service_test.rb
+++ b/test/services/updated_family_precheck_status_service_test.rb
@@ -38,6 +38,14 @@ class UpdatedFamilyPrecheckStatusServiceTest < ServiceTestCase
     assert_match 'Review Registration', email.body.to_s
   end
 
+  test 'updating the family without changing the status does not send mail' do
+    @family.update!(city: "Gotham", precheck_status: :pending_approval)
+
+    assert_no_difference -> { ActionMailer::Base.deliveries.size } do
+      UpdatedFamilyPrecheckStatusService.new(family: @family).call
+    end
+  end
+
   test 'changing to approved checks-in the attendees' do
     refute_equal Attendee::CONFERENCE_STATUS_CHECKED_IN, @attendee_one.reload.conference_status
     refute_equal Attendee::CONFERENCE_STATUS_CHECKED_IN, @attendee_two.reload.conference_status

--- a/test/services/updated_family_precheck_status_service_test.rb
+++ b/test/services/updated_family_precheck_status_service_test.rb
@@ -12,17 +12,30 @@ class UpdatedFamilyPrecheckStatusServiceTest < ServiceTestCase
     @attendee_two = create :attendee, family: @family, conference_status: Attendee::CONFERENCE_STATUSES.first
   end
 
-  test 'changing to pending_approval does nothing' do
+  test 'changing status from changes_requested to pending_approval does not affect attendee' do
     @family.update!(precheck_status: :changes_requested)
     @family.reload.update!(precheck_status: :pending_approval)
 
-    assert_no_difference -> { ActionMailer::Base.deliveries.size } do
-      assert_no_difference -> { @attendee_one.reload.updated_at } do
-        assert_no_difference -> { @attendee_two.reload.updated_at } do
-          UpdatedFamilyPrecheckStatusService.new(family: @family).call
-        end
+    assert_no_difference -> { @attendee_one.reload.updated_at } do
+      assert_no_difference -> { @attendee_two.reload.updated_at } do
+        UpdatedFamilyPrecheckStatusService.new(family: @family).call
       end
     end
+  end
+
+  test 'changing status from changes_requested to pending_approval sends mail' do
+    @family.update!(precheck_status: :changes_requested)
+    @family.reload.update!(precheck_status: :pending_approval)
+
+    assert_difference -> { ActionMailer::Base.deliveries.size }, 1 do
+      UpdatedFamilyPrecheckStatusService.new(family: @family).call
+    end
+
+    email = ActionMailer::Base.deliveries.last
+    assert_equal ['no-reply@cru.org'], email.from
+    assert_equal [@attendee_one.email, @attendee_two.email], email.to
+    assert_equal 'Cru17 - PreCheck Eligible', email.subject
+    assert_match 'Review Registration', email.body.to_s
   end
 
   test 'changing to approved checks-in the attendees' do


### PR DESCRIPTION
When precheck status is updated from `changes_requested` to `pending_approval`, we now send confirm charges email immediately instead of waiting for nightly precheck mailer.