### PR TITLE
Update precheck eligible status labels

### DIFF
--- a/app/helpers/precheck_helper.rb
+++ b/app/helpers/precheck_helper.rb
@@ -11,8 +11,20 @@ module PrecheckHelper
     PrecheckEligibilityService.new(family: family).actionable_errors
   end
 
-  def precheck_eligibility_error_label(error)
-    error.to_s.humanize
+  def precheck_eligibility_error_label(error, family)
+    {
+      not_checked_in_already?: 'Already checked-in',
+      not_changes_requested_status?: 'Changes are requested',
+      not_too_late?: 'Too late for PreCheck',
+      not_too_early?: 'Too early for PreCheck',
+      housing_preference_confirmed?: 'Housing assignment incomplete',
+      chargeable_staff_number_or_zero_balance?: 'Balance due',
+      children_forms_approved?: "Childcare forms not yet approved (#{names_of_children_without_approved_forms(family)})"
+    }[error.to_sym]
+  end
+
+  def names_of_children_without_approved_forms(family)
+    PrecheckEligibilityService.new(family: family).children_without_approved_forms.map(&:full_name).to_sentence
   end
 
   def precheck_status_label(arg)

--- a/app/helpers/precheck_helper.rb
+++ b/app/helpers/precheck_helper.rb
@@ -12,15 +12,7 @@ module PrecheckHelper
   end
 
   def precheck_eligibility_error_label(error, family)
-    {
-      not_checked_in_already?: 'Already checked-in',
-      not_changes_requested_status?: 'Changes are requested',
-      not_too_late?: 'Too late for PreCheck',
-      not_too_early?: 'Too early for PreCheck',
-      housing_preference_confirmed?: 'Housing assignment incomplete',
-      chargeable_staff_number_or_zero_balance?: 'Balance due',
-      children_forms_approved?: "Childcare forms not yet approved (#{names_of_children_without_approved_forms(family)})"
-    }[error.to_sym]
+    t("precheck_helper.eligibility_error_label.#{error}", names_of_children: names_of_children_without_approved_forms(family))
   end
 
   def names_of_children_without_approved_forms(family)
@@ -29,12 +21,7 @@ module PrecheckHelper
 
   def precheck_status_label(arg)
     status = arg.is_a?(Family) ? arg.precheck_status : arg
-
-    {
-      approved: 'PreCheck Accepted by Conferee',
-      changes_requested: 'Changes Requested by Conferee',
-      pending_approval: 'Pending Conferee Acceptance'
-    }[status.to_sym]
+    t("precheck_helper.status_label.#{status}")
   end
 
   def precheck_statuses_select_collection

--- a/app/views/families/_form.html.arb
+++ b/app/views/families/_form.html.arb
@@ -27,7 +27,7 @@ context.instance_exec do
     input :handicap, label: 'Using Handicapped parking (hanging tag required)'
   end
 
-  inputs 'Precheck' do
+  inputs t('.precheck') do
     input :precheck_status, as: :select, include_blank: false, collection: precheck_statuses_select_collection
   end
 

--- a/app/views/families/show/_precheck.html.arb
+++ b/app/views/families/show/_precheck.html.arb
@@ -4,10 +4,10 @@ context.instance_exec do
       row(:precheck_eligible?) do |family|
         status_tag(precheck_eligible?(family))
         if precheck_eligibility_errors(family).present?
-          div 'The following eligibility requirements were not met:'
+          div 'This family is not eligible due to the following reasons:'
           ul do
             precheck_eligibility_errors(family).each do |error|
-              li precheck_eligibility_error_label(error)
+              li precheck_eligibility_error_label(error, family)
             end
           end
         end

--- a/app/views/families/show/_precheck.html.arb
+++ b/app/views/families/show/_precheck.html.arb
@@ -1,10 +1,10 @@
 context.instance_exec do
-  panel 'Precheck' do
+  panel t('.precheck') do
     attributes_table_for family do
-      row(:precheck_eligible?) do |family|
+      row t('.precheck_eligible?') do |family|
         status_tag(precheck_eligible?(family))
         if precheck_eligibility_errors(family).present?
-          div 'This family is not eligible due to the following reasons:'
+          div t('.not_eligible', family: family.last_name)
           ul do
             precheck_eligibility_errors(family).each do |error|
               li precheck_eligibility_error_label(error, family)
@@ -13,15 +13,15 @@ context.instance_exec do
         end
       end
 
-      row(:precheck_status) do |family|
+      row t('.precheck_status') do |family|
         status_tag precheck_status_label(family)
       end
 
       row(:precheck_status_changed_at)
 
-      row('Precheck Page') do |family|
+      row t('.precheck_page') do |family|
         family.precheck_email_token || family.create_precheck_email_token!
-        link_to "Open #{family.last_name} family's precheck page",
+        link_to t('.open_family_precheck_page', family: family.last_name),
                 precheck_status_path(token: family.precheck_email_token.token),
                 target: '_blank'
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -172,6 +172,8 @@ en:
         country_code: "Country"
         staff_number: "Staff ID"
         zip: "Zip Code"
+        precheck_status: "PreCheck Status"
+        precheck_status_changed_at: "PreCheck Status Last Changed At"
       housing_facility:
         country_code: "Country"
         csu_dorm_code: "CSU Dorm Code"
@@ -331,6 +333,18 @@ en:
       title: "CruConference PreCheck"
       precheck: "PreCheck"
 
+  families:
+    show:
+      precheck:
+        precheck: 'PreCheck'
+        not_eligible: '%{family} family is not eligible due to the following reasons:'
+        precheck_eligible?: 'Precheck Eligible?'
+        precheck_status: 'Precheck Status'
+        precheck_page: 'Precheck Page'
+        open_family_precheck_page: "Open %{family} family's PreCheck page"
+    form:
+      precheck: 'PreCheck'
+
   precheck:
     confirmation:
       create:
@@ -367,6 +381,20 @@ en:
         request_changes_confirm: "Are you sure you want to request changes?"
         submit_request_changes: "Submit Request"
         cancel: "Cancel"
+
+  precheck_helper:
+    eligibility_error_label:
+      not_checked_in_already?: 'Already checked-in'
+      not_changes_requested_status?: 'Changes are requested'
+      not_too_late?: 'Too late for PreCheck'
+      not_too_early?: 'Too early for PreCheck'
+      housing_preference_confirmed?: 'Housing assignment incomplete'
+      chargeable_staff_number_or_zero_balance?: 'Balance due'
+      children_forms_approved?: "Childcare forms not yet approved [%{names_of_children}]"
+    status_label:
+      approved: 'PreCheck Accepted by Conferee'
+      changes_requested: 'Changes Requested by Conferee'
+      pending_approval: 'Pending Conferee Acceptance'
 
   family_mailer:
     summary:

--- a/test/services/precheck_eligibility_service_test.rb
+++ b/test/services/precheck_eligibility_service_test.rb
@@ -141,7 +141,7 @@ class PrecheckEligibilityServiceTest < ServiceTestCase
 
   test '#errors present when outside arrival window' do
     travel_to 1.month.from_now do
-      assert_equal [:within_arrival_time_window?], service.errors
+      assert_equal [:not_too_late?], service.errors
     end
   end
 
@@ -223,5 +223,10 @@ class PrecheckEligibilityServiceTest < ServiceTestCase
     @eligible_family.attendees.update_all(arrived_at: nil)
     @eligible_family.reload
     assert_nil service.too_late?
+  end
+
+  test '#children_without_approved_forms' do
+    @eligible_family.children.last.update! forms_approved: false, forms_approved_by: nil
+    assert_equal [@eligible_family.children.last], service.children_without_approved_forms
   end
 end


### PR DESCRIPTION
We've added a list of reasons why a family is not eligible for precheck into the admin panel. Andy has requested that we change the way that these reasons are displayed and this PR addresses that feedback.

https://basecamp.com/2160769/projects/12693955/todos/388548025#comment_699860989