### PR TITLE
Precheck confirm button checks eligibility every time

### DIFF
--- a/app/controllers/precheck/confirmation_controller.rb
+++ b/app/controllers/precheck/confirmation_controller.rb
@@ -1,5 +1,7 @@
 class Precheck::ConfirmationController < PrecheckController
   def create
+    redirect_to precheck_status_path and return unless PrecheckEligibilityService.new(family: @family).call
+
     @family.update!(precheck_status: :approved)
     UpdatedFamilyPrecheckStatusService.new(family: @family).call
   end

--- a/app/controllers/precheck/rejection_controller.rb
+++ b/app/controllers/precheck/rejection_controller.rb
@@ -1,6 +1,6 @@
 class Precheck::RejectionController < PrecheckController
   def create
-    redirect_to precheck_status_path and return unless PrecheckEligibilityService.new(family: @family).call
+    redirect_to precheck_status_path and return if PrecheckEligibilityService.new(family: @family).too_late?
 
     @family.update!(precheck_status: :changes_requested)
     @message = params['message']

--- a/app/controllers/precheck/rejection_controller.rb
+++ b/app/controllers/precheck/rejection_controller.rb
@@ -1,9 +1,16 @@
 class Precheck::RejectionController < PrecheckController
   def create
-    redirect_to precheck_status_path and return if PrecheckEligibilityService.new(family: @family).too_late?
+    redirect_to precheck_status_path and return if inelegible_for_precheck?
 
     @family.update!(precheck_status: :changes_requested)
     @message = params['message']
     UpdatedFamilyPrecheckStatusService.new(family: @family, message: @message).call
+  end
+
+  private
+
+  def inelegible_for_precheck?
+    elegibility_checker = PrecheckEligibilityService.new(family: @family)
+    elegibility_checker.too_late? || elegibility_checker.checked_in_already?
   end
 end

--- a/app/controllers/precheck/rejection_controller.rb
+++ b/app/controllers/precheck/rejection_controller.rb
@@ -1,5 +1,7 @@
 class Precheck::RejectionController < PrecheckController
   def create
+    redirect_to precheck_status_path and return unless PrecheckEligibilityService.new(family: @family).call
+
     @family.update!(precheck_status: :changes_requested)
     @message = params['message']
     UpdatedFamilyPrecheckStatusService.new(family: @family, message: @message).call

--- a/app/services/precheck_eligibility_service.rb
+++ b/app/services/precheck_eligibility_service.rb
@@ -42,6 +42,10 @@ class PrecheckEligibilityService < ApplicationService
     Time.zone.now > last_precheck_time
   end
 
+  def checked_in_already?
+    !not_checked_in_already?
+  end
+
   private
 
   def_delegator :family, :approved?

--- a/test/controllers/precheck/rejection_controller_test.rb
+++ b/test/controllers/precheck/rejection_controller_test.rb
@@ -18,7 +18,6 @@ class Precheck::RejectionControllerTest < ControllerTestCase
 
   test '#create with a valid token sends change request email' do
     token = create(:precheck_email_token)
-    PrecheckEligibilityService.stubs(:new).returns(stub(call: true))
 
     assert_equal token.family.reload.precheck_status, 'pending_approval'
     assert_no_difference('PrecheckEmailToken.count') do
@@ -36,7 +35,6 @@ class Precheck::RejectionControllerTest < ControllerTestCase
   test '#create when already in changes_requested state sends another change request email' do
     token = create(:precheck_email_token)
     token.family.update!(precheck_status: :changes_requested)
-    PrecheckEligibilityService.stubs(:new).returns(stub(call: true))
 
     assert_equal token.family.reload.precheck_status, 'changes_requested'
     assert_emails 1 do
@@ -49,10 +47,10 @@ class Precheck::RejectionControllerTest < ControllerTestCase
     assert_equal [UserVariable[:support_email]], last_email.to
   end
 
-  test '#create when precheck eligibility is false' do
+  test '#create when precheck eligibility is too late' do
     token = create(:precheck_email_token)
     @attendee = create(:attendee, family: token.family)
-    PrecheckEligibilityService.stubs(:new).returns(stub(call: false))
+    PrecheckEligibilityService.stubs(:new).returns(stub("too_late?": true))
 
     assert_equal @attendee.family.precheck_status, 'pending_approval'
 

--- a/test/controllers/precheck/rejection_controller_test.rb
+++ b/test/controllers/precheck/rejection_controller_test.rb
@@ -18,6 +18,7 @@ class Precheck::RejectionControllerTest < ControllerTestCase
 
   test '#create with a valid token sends change request email' do
     token = create(:precheck_email_token)
+    PrecheckEligibilityService.stubs(:new).returns(stub(call: true))
 
     assert_equal token.family.reload.precheck_status, 'pending_approval'
     assert_no_difference('PrecheckEmailToken.count') do
@@ -35,6 +36,7 @@ class Precheck::RejectionControllerTest < ControllerTestCase
   test '#create when already in changes_requested state sends another change request email' do
     token = create(:precheck_email_token)
     token.family.update!(precheck_status: :changes_requested)
+    PrecheckEligibilityService.stubs(:new).returns(stub(call: true))
 
     assert_equal token.family.reload.precheck_status, 'changes_requested'
     assert_emails 1 do
@@ -45,5 +47,19 @@ class Precheck::RejectionControllerTest < ControllerTestCase
     last_email = ActionMailer::Base.deliveries.last
     assert_equal "MyConfName PreCheck Changes Requested for Family #{token.family}", last_email.subject
     assert_equal [UserVariable[:support_email]], last_email.to
+  end
+
+  test '#create when precheck eligibility is false' do
+    token = create(:precheck_email_token)
+    @attendee = create(:attendee, family: token.family)
+    PrecheckEligibilityService.stubs(:new).returns(stub(call: false))
+
+    assert_equal @attendee.family.precheck_status, 'pending_approval'
+
+    assert_no_difference -> { ActionMailer::Base.deliveries.size } do
+      post :create, token: token.token
+    end
+    assert_equal @attendee.family.reload.precheck_status, 'pending_approval'
+    assert_redirected_to precheck_status_path
   end
 end


### PR DESCRIPTION
We now do a check of precheck eligibility when the user clicks confirm. If the user is not eligible on time of clicking confirm, they are redirected to a status page with a message notifying what to do next.

This avoids issues like user opening email, then leaving open over night and the user not being pre check eligible any more because its too late, or because some other detail changed between email being sent and user confirming.