### PR TITLE
Fix reports table pkey sequence

### DIFF
--- a/db/migrate/20190522165029_fix_reports_table_pkey_sequence.rb
+++ b/db/migrate/20190522165029_fix_reports_table_pkey_sequence.rb
@@ -4,5 +4,6 @@ class FixReportsTablePkeySequence < ActiveRecord::Migration
   end
 
   def down
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20190522165029_fix_reports_table_pkey_sequence.rb
+++ b/db/migrate/20190522165029_fix_reports_table_pkey_sequence.rb
@@ -1,0 +1,8 @@
+class FixReportsTablePkeySequence < ActiveRecord::Migration
+  def up
+    execute "SELECT SETVAL('ministries_id_seq', (SELECT MAX(id) FROM ministries));" 
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190426162641) do
+ActiveRecord::Schema.define(version: 20190522165029) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Reports table primary key sequence was out of sync, with this script we get the latest id present on the table and we set that as the value to continue the sequence from.

This is a harmless migration that can be run multiple times if desired with no side effects