### PR TITLE
Fix reports table pkey sequence

### DIFF
--- a/db/migrate/20190524181136_fix_reports_table_pkey_sequence.rb
+++ b/db/migrate/20190524181136_fix_reports_table_pkey_sequence.rb
@@ -1,0 +1,9 @@
+class FixReportsTablePkeySequence < ActiveRecord::Migration
+  def up
+    execute "SELECT SETVAL('reports_id_seq', (SELECT MAX(id) FROM reports));"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190426162641) do
+ActiveRecord::Schema.define(version: 20190524181136) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Reports table primary key sequence was out of sync, with this sql we get the latest id present on the table and we set that as the value to continue the sequence from.