### PR TITLE
Precheck email and web text updates

### DIFF
--- a/app/views/family_mailer/summary.html.erb
+++ b/app/views/family_mailer/summary.html.erb
@@ -1,6 +1,8 @@
+<h2 class="greeting"><%= t('precheck.status.show.greeting', last_name: @family.last_name) %></h2>
+
 <p>
   <% if @family.approved? %>
-    <%= t('.precheck_confirmed', conference: UserVariable[:conference_id]) %></p>
+    <%= t('.precheck_confirmed_html', conference: UserVariable[:conference_id]) %>
   <% else %>
     <%= t('.onsite_confirmed', conference: UserVariable[:conference_id]) %>
   <% end %>

--- a/app/views/layouts/precheck.html.erb
+++ b/app/views/layouts/precheck.html.erb
@@ -10,10 +10,6 @@
     <div class='precheck-container'>
       <%= image_tag(UserVariable[:conference_logo_url]) %>
       <br>
-      <br>
-      <% unless @family&.checked_in? && !@family&.approved? %>
-        <h1><%= [UserVariable[:conference_id], t('.precheck')].join(' ') %></h1>
-      <% end%>
       <%= yield %>
     </div>
   </body>

--- a/app/views/precheck/status/_checked_in.html.erb
+++ b/app/views/precheck/status/_checked_in.html.erb
@@ -1,6 +1,6 @@
 <p>
   <% if family.approved? %>
-    <%= t('family_mailer.summary.precheck_confirmed', conference: UserVariable[:conference_id]) %>
+    <%= t('precheck.confirmation.show.precheck_confirmed_html', conference: UserVariable[:conference_id]) %>
   <% else %>
     <%= t('family_mailer.summary.onsite_confirmed', conference: UserVariable[:conference_id]) %>
   <% end %>

--- a/app/views/precheck/status/_precheck_eligible.html.erb
+++ b/app/views/precheck/status/_precheck_eligible.html.erb
@@ -1,4 +1,4 @@
-<p><%= t('.financial_summary_preamble') %></p>
+<p><%= t('.financial_summary_preamble_html') %></p>
 <br>
 <br>
 

--- a/app/views/precheck/status/not_precheck_eligible/_eligibility_errors_with_form.html.erb
+++ b/app/views/precheck/status/not_precheck_eligible/_eligibility_errors_with_form.html.erb
@@ -8,7 +8,7 @@
 <br>
 
 <% precheck_eligibility_actionable_errors(family).each do |error| %>
-  <p><%= t(".eligibility_errors.#{error}") %></p>
+  <p><%= t(".eligibility_errors.#{error}_html") %></p>
   <br>
 <% end %>
 
@@ -19,3 +19,8 @@
   <br>
   <%= submit_tag(t('.submit'), class: 'btn btn-cancel', data: { confirm: t('.confirm'), disable_with: '...' }) %>
 <% end %>
+<br>
+<br>
+<br>
+<br>
+<p><%= t('.closing_message_html') %></p>

--- a/app/views/precheck/status/not_precheck_eligible/_too_late_for_precheck.html.erb
+++ b/app/views/precheck/status/not_precheck_eligible/_too_late_for_precheck.html.erb
@@ -1,1 +1,1 @@
-<p><%= t(".apology") %></p>
+<p><%= t(".apology_html") %></p>

--- a/app/views/precheck_mailer/confirm_charges.html.erb
+++ b/app/views/precheck_mailer/confirm_charges.html.erb
@@ -1,6 +1,6 @@
 <%= t('.body_html', conference: UserVariable[:conference_id]) %>
-
 <%= link_to t('.link'), precheck_status_url(token: @token.token) %>
+<br>
 <br>
 <p>
   <%= t("precheck_mailer.closing_html") %>

--- a/app/views/precheck_mailer/confirm_charges.html.erb
+++ b/app/views/precheck_mailer/confirm_charges.html.erb
@@ -1,5 +1,3 @@
-<h1><%= t('.title', conference: UserVariable[:conference_id]) %></h1>
-
 <%= t('.body_html', conference: UserVariable[:conference_id]) %>
 
 <%= link_to t('.link'), precheck_status_url(token: @token.token) %>

--- a/app/views/precheck_mailer/confirm_charges.html.erb
+++ b/app/views/precheck_mailer/confirm_charges.html.erb
@@ -3,3 +3,7 @@
 <%= t('.body_html', conference: UserVariable[:conference_id]) %>
 
 <%= link_to t('.link'), precheck_status_url(token: @token.token) %>
+<br>
+<p>
+  <%= t("precheck_mailer.closing_html") %>
+</p>

--- a/app/views/precheck_mailer/report_issues.html.erb
+++ b/app/views/precheck_mailer/report_issues.html.erb
@@ -1,13 +1,17 @@
+<h2 class="greeting"><%= t('precheck.status.show.greeting', last_name: @family.last_name) %></h2>
+
 <p>
-  <%= t('precheck.status.not_precheck_eligible.not_precheck_eligible_preamble') %>
+  <%= t('precheck_mailer.not_eligible_preamble_html') %>
 </p>
-<br>
 
 <% precheck_eligibility_actionable_errors(@family).each do |error| %>
   <p>
-    <%= t("precheck.status.not_precheck_eligible.eligibility_errors.#{error}") %>
+    <%= t("precheck_mailer.eligibility_errors.#{error}_html") %>
   </p>
-  <br>
 <% end %>
-
 <%= link_to t('.link'), precheck_status_url(token: @token.token) %>
+<br>
+<br>
+<p>
+  <%= t("precheck_mailer.closing_html") %>
+</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -468,7 +468,6 @@ en:
   precheck_mailer:
     confirm_charges:
       subject: "%{conference} - PreCheck Eligible"
-      title: "%{conference} PreCheck"
       body_html:
         <p>Good news! Your Summer19/Cru19 registration is <b>eligible for PreCheck.</b>
         <br>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -351,17 +351,33 @@ en:
       create:
         title: "Congratulations!"
         body: "You have received PreCheck. You will receive a confirmation email shortly with more details for your arrival."
+      show:
+        precheck_confirmed_html:
+          Congratulations! You have received <b>PreCheck</b>.
+          <br>
+          <br>
+          When you arrive for check-in, please go to the <b>Durrell Center</b> (across from Moby Arena, near the corner of Shields and Plum) where your name tags and other conference materials will be waiting for you. Look for the PreCheck signs and Team19 workers who will point you in the right direction. If you are parking a car on campus, don’t forget to snap a photo of your license plate to submit upon arrival.
+          <br>
+          <br>
+          For those attending IBS, please stop by the IBS tables for class notes and optional seminary credit.
+          <br>
+          <br>
+          Completing your check-in today means you <i>do not</i> need to return to check in again on July 19. Please keep your name tag throughout the summer, including %{conference}. You will also receive a security wristband and a clear bag for %{conference} through your track leader. 
     rejection:
       create:
-        title: "Request received."
-        body: "The conference team has been notified of your request and will contact you as soon as possible."
+        title: "We have received your request."
+        body: "Thank you for contacting us. Team19 is working hard to answer all your questions and we hope to get back to you within 24-48 hours."
         message: "The message you sent was:"
     status:
       show:
         greeting: "Hello %{last_name} family!"
       not_precheck_eligible:
         too_late_for_precheck:
-          apology: "Sorry, it is now too late to qualify for PreCheck. Please check-in when you arrive on-site."
+          apology_html:
+            We are sorry. PreCheck has closed and Team19 is working hard to prepare for your arrival.
+            <br>
+            <br>
+            Please do not worry. You will still have a great check-in experience with friendly service, shorter lines, the ability to confirm your information in person and get answers to your questions. When you arrive at CSU, look for the signs and Team19 members who will direct you to the check-in area.
         eligibility_errors_with_form:
           closing_message_html:
             We want to help you receive PreCheck to expedite your check-in at Summer19/Cru19. <b>However, if you do not receive PreCheck clearance, do not worry!</b> When you arrive on campus, look for the signs and Team19 members who will direct you to the check-in area. You will have a great experience with friendly service, shorter lines, and answers to your questions.
@@ -442,9 +458,10 @@ en:
       contact_list_preamble: "For questions regarding:"
       contact_list_html: '<ul>
           <li>Kids Care / Kids Camp, please contact <a href="mailto:Cru19.Childcare@cru.org">Cru19.Childcare@cru.org</a> </li>
-          <li>Jr. High / Sr. High Program, please contact <a href="mailto:Cru19.JrSrHigh@cru.org">Cru19.JrSrHigh@cru.org</a> </li>
-          <li>finances, please contact <a href="mailto:Cru19.Finance@cru.org">Cru19.Finance@cru.org</a></li>
-          <li>anything else, please contact <a href="mailto:Cru19.Info@cru.org">Cru19.Info@cru.org</a></li>
+          <li>CruStu, please contact <a href="mailto:Cru19.CruStu@cru.org">Cru19.CruStu@cru.org</a></li>
+          <li>Housing, please contact <a href="mailto:Cru19.OffCampus@cru.org">Cru19.OffCampus@cru.org</a> and <a href="mailto:Cru19.OnCampus@cru.org">Cru19.OnCampus@cru.org</a></li>
+          <li>Finances, please contact <a href="mailto:Cru19.Finance@cru.org">Cru19.Finance@cru.org</a></li>
+          <li>Anything else, please contact <a href="mailto:Cru19.Info@cru.org">Cru19.Info@cru.org</a></li>
         </ul>'
       signature_html: "<p>Sincerely,<br><br>%{conference} Team</p>"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -363,15 +363,33 @@ en:
         too_late_for_precheck:
           apology: "Sorry, it is now too late to qualify for PreCheck. Please check-in when you arrive on-site."
         eligibility_errors_with_form:
+          closing_message_html:
+            We want to help you receive PreCheck to expedite your check-in at Summer19/Cru19. <b>However, if you do not receive PreCheck clearance, do not worry!</b> When you arrive on campus, look for the signs and Team19 members who will direct you to the check-in area. You will have a great experience with friendly service, shorter lines, and answers to your questions.
           changes_requested_preamble: "You've submitted a change request, your registration is undergoing review by our team."
-          not_precheck_eligible_preamble: 'You are not eligible for PreCheck at this moment.'
-          request_changes_preamble: "If you would like to request help or to send us a message, please type a message in the box below and click Submit Request to notify us of your request."
+          not_precheck_eligible_preamble: 'We are missing some conference details that will keep you from receiving PreCheck.'
+          request_changes_preamble: "If you would like to request help or to send us a message, please type a message in the box below and click Submit Request and one of our team members will get in touch with you."
           placeholder: 'Include your request or message in this box'
           confirm: 'Are you sure you want to send this request?'
           submit: 'Submit Request'
           eligibility_errors:
-            chargeable_staff_number_or_zero_balance?: 'no_chargeable_staff_number_and_finance_balance_not_zero'
-            children_forms_approved?: 'children_forms_not_approved'
+            chargeable_staff_number_or_zero_balance?_html: 
+              We noticed on your registration that we do not have your payment information.
+              <br>
+              If you are able to provide that up to 24 hours before your arrival, we can offer you PreCheck.
+              <br>
+              <br>
+              <ul>
+                <li>If you are an <b>employee of Cru in any capacity</b>, please type your employee ID (staff account number) or ministry chartfield in the message box below so that we can verify it and add it to your registration.</li>
+                <li>If you are <b>paying with a credit card</b>, it is unsafe to provide that information online. Please call 970-236-9555 between 9.00 AM – 4.30 PM MST and a Team19 staff member can process your payment.</li>
+                <li>If you have <b>another financial question</b> or would like to request help, type a message in the box below, click ‘Submit Request’ and a Team19 staff member will be in touch with you.</li>
+              </ul>
+            children_forms_approved?_html:
+              We noticed that you have incomplete Cru19 Kids forms which can still be submitted online.
+              <br>
+              Please refer to the DocuSign email packet in your inbox to reference the remaining forms we need.
+              <br>
+              <br>
+              Once they are signed and submitted using the steps outlined in the email, the CruKids team will notify you that they are complete. You have up to 24 hours before your arrival to complete this step and become eligible for PreCheck.
       precheck_eligible:
         financial_summary_preamble: "If your personal details and your conference cost breakdown are correct, please click below to confirm your PreCheck."
         confirm_precheck: "Yes, I accept my choices and charges"
@@ -433,6 +451,40 @@ en:
     report_issues:
       subject: "%{conference} - PreCheck Issues"
       link: "Click here to contact us"
+    closing_html: 
+      We look forward to seeing you in Colorado this summer.
+      <br>
+      <br>
+      Thank you,
+      <br>
+      Team19
+      <br>
+      <br>
+      P.S. We want to help you receive PreCheck to expedite your check-in at Summer19/Cru19.
+      <br>
+      We will send a reminder each day until you (or your spouse, if applicable) have successfully resolved your conference details.
+    not_eligible_preamble_html: 
+      Team19 is pleased to offer <b>PreCheck</b> at Summer19/Cru19.
+      This new experience allows you to confirm your conference details ahead of time so that you can qualify for express check-in at CSU.
+      <br>
+      We desire for you to receive PreCheck so that your time can be spent connecting with friends, settling in, and enjoying the Fort Collins area.
+    eligibility_errors:
+      chargeable_staff_number_or_zero_balance?_html:
+        At this time, you have a <b>balance due</b> that does not qualify you for PreCheck.
+        <br>
+        We would like to try and resolve your balance before you arrive so that you receive PreCheck.
+        <br>
+        <br>
+        <b>Please click on the link below</b> and read the options you have to take care of your balance.
+        <br>
+        When your balance is paid in full, you will receive another email indicating that you are now eligible for PreCheck and you will have the opportunity to review and confirm your conference information.
+      children_forms_approved?_html:
+        At this time, you have <b>incomplete Cru19 Kids forms</b> that do not qualify you for PreCheck.
+        <br>
+        We would like to help you submit the forms before you arrive so that you can receive PreCheck. 
+        <br>
+        <br>
+        <b>Please click on the link below</b> to learn what form(s) are still needed and how you can submit them through DocuSign.
 
   services:
     childcare:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -350,7 +350,7 @@ en:
     confirmation:
       create:
         title: "Congratulations!"
-        body: "You and your family (if applicable) have received %{conference} PreCheck. You should receive a confirmation email shortly with more details for your arrival."
+        body: "You have received PreCheck. You will receive a confirmation email shortly with more details for your arrival."
     rejection:
       create:
         title: "Request received."
@@ -422,7 +422,21 @@ en:
   family_mailer:
     summary:
       subject: "%{conference} Financial Summary"
-      precheck_confirmed: "Congratulations! You and your family (if applicable) have received %{conference} PreCheck. When you arrive for check in at the Durrell Center (dates and times to be changed for each one???) your name tags and other conference materials will be waiting for you. If you are checking in for IBS, you will still need to stop by the IBS tables to receive your class notes and optional seminary credit."
+      precheck_confirmed_html: 
+        Congratulations! You have received <b>PreCheck</b>.
+        <br>
+        <br>
+        When you arrive for check-in, please go to the <b>Durrell Center</b> (across from Moby Arena, near the corner of Shields and Plum) where your name tags and other conference materials will be waiting for you.
+        <br>
+        Look for the PreCheck signs and Team19 members, who will point you in the right direction.
+        <br>
+        If you are parking a car on campus, don’t forget to snap a photo of your license plate to submit upon arrival.
+        <br>
+        <br>
+        If you are staying on campus in a dorm, please review this helpful <a href="https://drive.google.com/file/d/1Jb8dN8jMT2-jvWBWmlYNnFy-8ootoonb/view?usp=sharing" target="_blank">arrival and dining hall information.</a>
+        <br>
+        <br>
+        We look forward to seeing you in Colorado this summer.
       onsite_confirmed: "Welcome to Summer19/%{conference}"
       summary_preamble: "Below is your conference registration summary."
       contact_list_preamble: "For questions regarding:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -391,10 +391,14 @@ en:
               <br>
               Once they are signed and submitted using the steps outlined in the email, the CruKids team will notify you that they are complete. You have up to 24 hours before your arrival to complete this step and become eligible for PreCheck.
       precheck_eligible:
-        financial_summary_preamble: "If your personal details and your conference cost breakdown are correct, please click below to confirm your PreCheck."
+        financial_summary_preamble_html:
+          Please carefully review your Summer19/Cru19 details. If your personal information and conference cost breakdown are correct, click “Yes, I accept my choices and charges”. This opportunity to receive PreCheck closes 24 hours before your arrival. 
+          <br>
+          <br>
+          If you see something that is incorrect or has changed since registering, click on “No, I need to request changes.”
         confirm_precheck: "Yes, I accept my choices and charges"
         confirm_precheck_confirm: "Are you sure you reviewed your details and want to confirm your PreCheck?"
-        request_changes_preamble: "If you would like to request a change or if there is a mistake on your profile or charges, please type a message in the box below and click the Submit Request button to notify us."
+        request_changes_preamble: "In the message box, please type the reason or situation that caused you to request a change so that one of our Team19 staff can help. Click the “Submit Request” button to notify us. You are still eligible to receive PreCheck up to 24 hours before your arrival and we will do our best to resolve your situation before you arrive on campus."
         request_changes_placeholder: "Include your change request or message in this box"
         request_changes: "No, I need to request changes..."
         request_changes_confirm: "Are you sure you want to request changes?"
@@ -434,13 +438,19 @@ en:
     confirm_charges:
       subject: "%{conference} - PreCheck Eligible"
       title: "%{conference} PreCheck"
-      body_html: "<p>Good news! Your Summer19 and/or %{conference} registration is eligible for PreCheck. This new system allows those who have PreCheck to pick up conference materials when they arrive at the Durrell Center on the CSU campus without visiting a computer check-in station.</p>
-
-      <p>To receive PreCheck, please click on the link below, review your registration choices, and click ACCEPT if they are correct.</p>
-
-      <p>If you notice that some of your choices have changed since you registered, you should click CHANGE, and we will update those options for you. After we’ve made the changes, you’ll once again receive this email so that you can choose to receive PreCheck.</p>
-
-      <p>NOTE: You will receive this email every day until you click ACCEPT or CHANGE.</p>"
+      body_html:
+        <p>Good news! Your Summer19/Cru19 registration is <b>eligible for PreCheck.</b>
+        <br>
+        <br>
+        This new experience allows you to confirm your conference details ahead of time and qualify for express check-in at CSU.
+        <br>
+        We desire for you to receive PreCheck so that your time can be spent connecting with friends, settling in, and enjoying the Fort Collins area.
+        <br>
+        <br>
+        <b>To receive PreCheck</b>, please click the link below, up to 24 hours before your arrival, to review your registration details.
+        <br>
+        Follow the instructions to confirm PreCheck or request changes. You will receive a reply email with further instructions on what to do when you arrive.
+        </p>
       link: "Review Registration"
     changes_requested:
       subject: "%{conference} PreCheck Changes Requested for Family %{family}"

--- a/test/integration/precheck/confirm/create_test.rb
+++ b/test/integration/precheck/confirm/create_test.rb
@@ -16,7 +16,7 @@ class Precheck::ConfirmationController::CreateTest < IntegrationTest
   test '#create' do
     visit precheck_status_path(token: @eligible_family.precheck_email_token.token)
     click_button 'Yes, I accept my choices and charges'
-    assert_text 'You and your family (if applicable) have received Cru17 PreCheck'
+    assert_text 'Congratulations! You have received PreCheck'
     assert @eligible_family.reload.approved?
     assert_equal Attendee::CONFERENCE_STATUS_CHECKED_IN, @eligible_family.attendees.first.conference_status
   end

--- a/test/integration/precheck/rejection/create_test.rb
+++ b/test/integration/precheck/rejection/create_test.rb
@@ -23,7 +23,7 @@ class Precheck::RejectionController::CreateTest < IntegrationTest
     page.driver.browser.switch_to.alert.accept
     wait_for_ajax!
 
-    assert_text 'Request received'
+    assert_text 'We have received your request'
     assert @eligible_family.reload.changes_requested?
   end
 end

--- a/test/integration/precheck/status/show_test.rb
+++ b/test/integration/precheck/status/show_test.rb
@@ -24,13 +24,13 @@ class Precheck::StatusController::ShowTest < IntegrationTest
   test '#show' do
     visit precheck_status_path(token: @eligible_family.precheck_email_token.token)
     assert_text "Hello #{@eligible_family.last_name} family!"
-    assert_text 'please click below to confirm your PreCheck'
+    assert_text 'If your personal information and conference cost breakdown are correct'
     assert_text 'Remaining Balance Due $0'
   end
 
   test '#show as not eligible family' do
     visit precheck_status_path(token: @not_eligible_family.precheck_email_token.token)
-    assert_text 'You are not eligible for PreCheck'
+    assert_text 'We are missing some conference details that will keep you from receiving PreCheck'
   end
 
   test '#show as not eligible family submits message' do
@@ -43,13 +43,13 @@ class Precheck::StatusController::ShowTest < IntegrationTest
       end
     end
 
-    assert_text 'The conference team has been notified'
+    assert_text 'Thank you for contacting us'
   end
 
   test '#show as eligible family pending approval' do
     @eligible_family.update!(precheck_status: :pending_approval)
     visit precheck_status_path(token: @eligible_family.precheck_email_token.token)
-    assert_text 'please click below to confirm your PreCheck'
+    assert_text 'click “Yes, I accept my choices and charges”'
   end
 
   test '#show as previously eligible family now has changes requested' do
@@ -61,7 +61,7 @@ class Precheck::StatusController::ShowTest < IntegrationTest
   test '#show as precheck approved' do
     @eligible_family.update!(precheck_status: :approved)
     visit precheck_status_path(token: @eligible_family.precheck_email_token.token)
-    assert_text 'Congratulations! You and your family (if applicable) have received Cru17 PreCheck'
+    assert_text 'Congratulations! You have received PreCheck'
   end
 
   test '#show as checked in on site' do
@@ -75,12 +75,12 @@ class Precheck::StatusController::ShowTest < IntegrationTest
   test '#show too late for precheck' do
     travel_to 5.days.from_now.end_of_day do
       visit precheck_status_path(token: @eligible_family.precheck_email_token.token)
-      assert_text 'please click below to confirm your PreCheck'
+      assert_text 'If your personal information and conference cost breakdown are correct'
     end
 
     travel_to 7.days.from_now.beginning_of_day do
       visit precheck_status_path(token: @eligible_family.precheck_email_token.token)
-      assert_text 'Sorry, it is now too late to qualify for PreCheck.'
+      assert_text 'We are sorry. PreCheck has closed and Team19 is working hard to prepare for your arrival.'
     end
   end
 end

--- a/test/services/updated_family_precheck_status_service_test.rb
+++ b/test/services/updated_family_precheck_status_service_test.rb
@@ -66,7 +66,7 @@ class UpdatedFamilyPrecheckStatusServiceTest < ServiceTestCase
     assert_equal ['no-reply@cru.org'], email.from
     assert_equal @family.attendees.map(&:email).sort, email.to.sort
     assert_equal 'Cru17 Financial Summary', email.subject
-    assert_match 'Congratulations! You and your family (if applicable) have received Cru17 PreCheck.', email.body.to_s
+    assert_match 'Congratulations! You have received <b>PreCheck</b>.', email.body.to_s
   end
 
   test 'changing to changes_requested does not affect attendees' do


### PR DESCRIPTION
Text changes for emails and web [following details on this readme](https://docs.google.com/document/d/1IoDiBabX1VBA--mUP3SmHk4CrEH5qkTH1UjruJrrBY8/edit)

Only missing one is the unsupported state of "Too early for precheck..."

### 1.a. You’re not eligible for PreCheck - Balance due:
<img width="1083" alt="Not eligible - balance due (mail)" src="https://user-images.githubusercontent.com/41801902/58520018-cbf72900-816a-11e9-8d9e-6ebdc63072ff.png">
<img width="1000" alt="Not eligible - balance due (web)" src="https://user-images.githubusercontent.com/41801902/58520019-cc8fbf80-816a-11e9-8296-a1e18cab58e2.png">
### 1.b. You’re not eligible for PreCheck - Childcare Pending:
<img width="1040" alt="Not eligible - childcare pending (mail)" src="https://user-images.githubusercontent.com/41801902/58520020-cc8fbf80-816a-11e9-87ba-6b9de15ebf36.png">
<img width="1021" alt="Not eligible - childcare pending (web)" src="https://user-images.githubusercontent.com/41801902/58520021-cc8fbf80-816a-11e9-8e7b-589b6caf5151.png">

### 2. You are eligible for PreCheck
<img width="815" alt="Eligible (mail)" src="https://user-images.githubusercontent.com/41801902/58520081-15e00f00-816b-11e9-8f3c-661cf9b1b63e.png">
<img width="1077" alt="Eligible (web - bottom)" src="https://user-images.githubusercontent.com/41801902/58520083-15e00f00-816b-11e9-8581-eee4e15007d7.png">
<img width="1029" alt="Eligible (web - change request)" src="https://user-images.githubusercontent.com/41801902/58520084-15e00f00-816b-11e9-969d-c8843f7707a4.png">
<img width="1013" alt="Eligible (web - top)" src="https://user-images.githubusercontent.com/41801902/58520086-15e00f00-816b-11e9-94c1-9256e7916123.png">

### 3. Your PreCheck is confirmed.
<img width="1084" alt="Confirmed (mail)" src="https://user-images.githubusercontent.com/41801902/58520104-2ee8c000-816b-11e9-992b-6858bf0a5acd.png">
<img width="1012" alt="Confirmed (web)" src="https://user-images.githubusercontent.com/41801902/58520105-2ee8c000-816b-11e9-97a9-0f9b514bc400.png">

### 4. Status web pages:
<img width="1022" alt="Already checked in in-person (web)" src="https://user-images.githubusercontent.com/41801902/58520122-49bb3480-816b-11e9-8b16-f5b2aecbb737.png">
<img width="996" alt="Already Checked In thorugh PreCheck (web)" src="https://user-images.githubusercontent.com/41801902/58520123-4a53cb00-816b-11e9-9123-6963d0cf8e2c.png">
<img width="966" alt="Change requested (web)" src="https://user-images.githubusercontent.com/41801902/58520124-4a53cb00-816b-11e9-8e41-3c9bb83b8975.png">
<img width="941" alt="Too late for PreCheck (web)" src="https://user-images.githubusercontent.com/41801902/58520125-4a53cb00-816b-11e9-9420-6cf0dfdd922c.png">



