### PR TITLE
Enhance action required by team section

### DIFF
--- a/app/admin/family.rb
+++ b/app/admin/family.rb
@@ -246,6 +246,14 @@ ActiveAdmin.register Family do
     end
   end
 
+  member_action :toggle_action_required_by_team, method: :post do
+    @family = Family.find(params[:id])
+    team = params[:team]
+
+    @family.toggle_required_team_action(team)
+    redirect_to family_path(@family)
+  end
+
   controller do
     def update
       update! do |format|

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -133,3 +133,25 @@ body.housing {
     margin: 0;
   }
 }
+
+a.checkbox-button {
+  text-decoration: none;
+  color: #323537;
+  margin-right: 20px;
+
+  &:hover {
+    opacity: 0.8;
+    color: #12405a;
+  }
+
+  &::before {
+    font: 20px/1 'Open Sans', sans-serif;
+    content: '\02610';
+  }
+}
+
+a.checkbox-button-checked::before {
+  font: 20px/1 'Open Sans', sans-serif;
+  content: '\02611';
+}
+

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -99,6 +99,16 @@ class Family < ApplicationRecord
     super Array(value).reject(&:blank?)
   end
 
+  def toggle_required_team_action(team)
+    return unless team && REQUIRED_ACTION_TEAMS.include?(team)
+
+    if required_team_action.include?(team)
+      update(required_team_action: (required_team_action - [team]))
+    else
+      update(required_team_action: (required_team_action + [team]))
+    end
+  end
+
   private
 
   def remove_blank_housing_preference

--- a/app/views/families/show/_precheck.html.arb
+++ b/app/views/families/show/_precheck.html.arb
@@ -25,7 +25,10 @@ context.instance_exec do
                 precheck_status_path(token: family.precheck_email_token.token),
                 target: '_blank'
       end
-      row :required_team_action
+
+      row :required_team_action do |family|
+        render 'families/show/precheck_actions', context: self, family: family
+      end
     end
   end
 end

--- a/app/views/families/show/_precheck_actions.html.erb
+++ b/app/views/families/show/_precheck_actions.html.erb
@@ -1,0 +1,4 @@
+<% Family::REQUIRED_ACTION_TEAMS.each do |team| %>
+  <% html_class = "checkbox-button #{'checkbox-button-checked' if family.required_team_action.include?(team)}" %>
+  <%= link_to team, toggle_action_required_by_team_family_path(family, team: team), method: :post, class: html_class %>
+<% end %>

--- a/test/models/family_test.rb
+++ b/test/models/family_test.rb
@@ -114,4 +114,19 @@ class FamilyTest < ModelTestCase
 
     assert [], @family.required_team_action
   end
+
+  test '#toggle_required_team_action' do
+    @family.update(required_team_action: Family::REQUIRED_ACTION_TEAMS)
+
+    @family.toggle_required_team_action(Family::REQUIRED_ACTION_TEAMS[1])
+    assert_equal (Family::REQUIRED_ACTION_TEAMS - [Family::REQUIRED_ACTION_TEAMS[1]]).sort, @family.required_team_action.sort
+
+    @family.toggle_required_team_action(Family::REQUIRED_ACTION_TEAMS[1])
+    assert_equal Family::REQUIRED_ACTION_TEAMS.sort, @family.required_team_action.sort
+
+    assert_nil @family.toggle_required_team_action('batman')
+    assert_nil @family.toggle_required_team_action('')
+    assert_nil @family.toggle_required_team_action(nil)
+    assert_equal Family::REQUIRED_ACTION_TEAMS.sort, @family.required_team_action.sort
+  end
 end


### PR DESCRIPTION
Expose links (wearing a checkbox costume), to allow adding / removing teams that need to review a family record on the family show page. (Without having to go to edit family form!)
User can still edit the checkboxes on the edit mode if desired.

<img width="643" alt="Screen Shot 2019-06-06 at 5 18 34 PM" src="https://user-images.githubusercontent.com/41801902/59074232-63e9c680-887f-11e9-9304-8d80244c4635.png">
<img width="632" alt="Screen Shot 2019-06-06 at 5 18 48 PM" src="https://user-images.githubusercontent.com/41801902/59074233-63e9c680-887f-11e9-9c91-80898925c3a8.png">

Next possible upgrade would be to do this via ajax call, but in the essence of time, page reload seems to be good enough.
