### PR TITLE
Fix docusign envelope when no cohort

### DIFF
--- a/app/services/childcare/send_docusign_envelope.rb
+++ b/app/services/childcare/send_docusign_envelope.rb
@@ -841,7 +841,7 @@ class Childcare::SendDocusignEnvelope < ApplicationService
   end
 
   def get_cohort_for(recipient)
-    recipient.cohort.name if recipient.campus_ministry_member?
+    recipient.cohort&.name if recipient.campus_ministry_member?
   end
 
   def check_if_in_list(existing_conditions, condition)

--- a/test/services/childcare/send_docusign_envelope_test.rb
+++ b/test/services/childcare/send_docusign_envelope_test.rb
@@ -31,6 +31,11 @@ class Childcare::SendDocusignEnvelopeTest < ServiceTestCase
     end
   end
 
+  test '#get_cohort_for does not crash if campus ministry cohort is missing' do
+    @attendee.ministry.parent = create(:ministry, code: 'CM')
+    assert '', Childcare::SendDocusignEnvelope.new(@child).send(:get_cohort_for, @attendee)
+  end
+
   test "#determine_docusign_template for a child on childcare grade and 'None of the above' misc health issue checked" do
     @child.grade_level = 'grade5'
     ChildcareMedicalHistory.new(child: @child, health_misc: ['None of the above'])


### PR DESCRIPTION
For now we will address this by just returning a blank value for the cohort, this way the envelope can still be sent but the cohort will just be blank.

https://basecamp.com/2160769/projects/12693955/todos/389807028