### PR TITLE
Nginx forces ssl, and rails 4 doesn't support ssl exclude

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,15 +42,15 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  if ENV["AWS_EXECUTION_ENV"].present?
-    # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-    config.force_ssl = true
-    config.ssl_options = {
-      redirect: {
-        exclude: -> (request) { request.fullpath == '/monitors/lb' }
-      }
-    }
-  end
+  # if ENV["AWS_EXECUTION_ENV"].present?
+  #   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  #   config.force_ssl = true
+  #   config.ssl_options = {
+  #     redirect: {
+  #       exclude: -> (request) { request.fullpath == '/monitors/lb' }
+  #     }
+  #   }
+  # end
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
This app still uses Rails 4 which doesn't support ssl_options exclude. It's easier to remove force_ssl here than to update the ALB target_group to allow 301 health check responses.