### PR TITLE
Feat/docusign and csv changes 2025

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ ARG SECRET_KEY_BASE=b12374ce07c365986c3be4fa417fe9248242c64bb4aec0dc04c6562a08b0
 ARG IDP_SSO_TARGET_URL="https://dev-54692893.okta.com/app/dev-54692893_cruconfdev_1/exk9ofqjjbx7hfHkr5d7/sso/saml"
 ARG SP_ENTITY_ID="SCO"
 ARG IDP_CERT= "-----BEGIN CERTIFICATE----------END CERTIFICATE-----"
+ARG EXTERNAL_API_KEY="b07f8a12a309f418b1d3aebc35d6e4a6c117ecfd0174a8c5b5e4c72d1cdd8f7e"
 
 # Compile assets
 RUN RAILS_ENV=${RAILS_ENV} SECRET_KEY_BASE_DUMMY=1 bundle exec rake assets:clobber assets:precompile \

--- a/app/admin/chargeable_staff_number.rb
+++ b/app/admin/chargeable_staff_number.rb
@@ -14,8 +14,7 @@ ActiveAdmin.register ChargeableStaffNumber do
     return head :forbidden unless authorized?(:import, ChargeableStaffNumber)
 
     import_params =
-      ActionController::Parameters.new(params).require('import_spreadsheet').
-        permit(:file, :delete_existing, :skip_first)
+      params.require('import_spreadsheet').permit(:file, :delete_existing, :skip_first)
 
     job = UploadJob.create!(user_id: current_user.id,
                             filename: import_params[:file].path)

--- a/app/admin/child.rb
+++ b/app/admin/child.rb
@@ -17,7 +17,7 @@ ActiveAdmin.register Child do
     :needs_bed, :grade_level, :childcare_id, :arrived_at, :departed_at,
     :name_tag_first_name, :name_tag_last_name, :childcare_deposit,
     :childcare_comment, :rec_pass_start_at, :rec_pass_end_at, :forms_approved, :forms_approved_by,
-    :tshirt_size,
+    :tshirt_size, :childcare_cancellation_fee, :childcare_late_fee, :county,
     childcare_weeks: [], hot_lunch_weeks: [], 
     cost_adjustments_attributes: %i[
       id _destroy description person_id price percent cost_type
@@ -28,7 +28,7 @@ ActiveAdmin.register Child do
       vip_comm_addl vip_comm_small vip_comm_large vip_comm_directions vip_stress_addl
       vip_stress_behavior vip_calm vip_hobby vip_buddy vip_addl_info sunscreen_self sunscreen_assisted
       sunscreen_provided cc_allergies cc_vip_developmental_age cc_medi_allergy cc_vip_staff_administered_meds non_immunizations
-      cc_vip_sitting
+      cc_vip_sitting cc_restriction_certified
     ] << ChildcareMedicalHistory.multi_selection_collections.transform_values { |_| [] },
     cru_student_medical_history_attributes: %i[
       id _destroy date parent_agree gtky_lunch gtky_signout gtky_sibling_signout gtky_sibling cs_allergies cs_chronic_health

--- a/app/admin/child.rb
+++ b/app/admin/child.rb
@@ -23,14 +23,14 @@ ActiveAdmin.register Child do
       id _destroy description person_id price percent cost_type
     ],
     childcare_medical_history_attributes: %i[
-      id _destroy date allergy food_intolerance chronic_health_addl medications
-      restrictions vip_meds vip_dev vip_strengths vip_challenges vip_mobility vip_walk
+      id _destroy date allergy food_intolerance chronic_health_addl medications other_special_needs chronic_health
+      restrictions vip_meds vip_dev vip_strengths vip_challenges vip_mobility vip_walk medi_allergy
       vip_comm_addl vip_comm_small vip_comm_large vip_comm_directions vip_stress_addl
       vip_stress_behavior vip_calm vip_hobby vip_buddy vip_addl_info sunscreen_self sunscreen_assisted
-      sunscreen_provided
+      sunscreen_provided cc_allergies
     ] << ChildcareMedicalHistory.multi_selection_collections.transform_values { |_| [] },
     cru_student_medical_history_attributes: %i[
-      id _destroy date parent_agree gtky_lunch gtky_signout gtky_sibling_signout gtky_sibling
+      id _destroy date parent_agree gtky_lunch gtky_signout gtky_sibling_signout gtky_sibling cs_allergies cs_chronic_health
       gtky_small_group_friend gtky_musical gtky_activities gtky_gain gtky_growth gtky_addl_info gtky_addl_challenges
       gtky_large_groups gtky_small_groups gtky_is_leader gtky_leader gtky_is_follower gtky_friends gtky_hesitant
       gtky_active gtky_reserved gtky_boundaries gtky_authority gtky_adapts gtky_allergies med_allergies

--- a/app/admin/child.rb
+++ b/app/admin/child.rb
@@ -23,11 +23,12 @@ ActiveAdmin.register Child do
       id _destroy description person_id price percent cost_type
     ],
     childcare_medical_history_attributes: %i[
-      id _destroy date allergy food_intolerance chronic_health_addl medications other_special_needs chronic_health
+      id _destroy date allergy food_intolerance chronic_health_addl medications cc_other_special_needs chronic_health
       restrictions vip_meds vip_dev vip_strengths vip_challenges vip_mobility vip_walk medi_allergy
       vip_comm_addl vip_comm_small vip_comm_large vip_comm_directions vip_stress_addl
       vip_stress_behavior vip_calm vip_hobby vip_buddy vip_addl_info sunscreen_self sunscreen_assisted
-      sunscreen_provided cc_allergies
+      sunscreen_provided cc_allergies cc_vip_developmental_age cc_medi_allergy cc_vip_staff_administered_meds non_immunizations
+      cc_vip_sitting
     ] << ChildcareMedicalHistory.multi_selection_collections.transform_values { |_| [] },
     cru_student_medical_history_attributes: %i[
       id _destroy date parent_agree gtky_lunch gtky_signout gtky_sibling_signout gtky_sibling cs_allergies cs_chronic_health
@@ -35,10 +36,11 @@ ActiveAdmin.register Child do
       gtky_large_groups gtky_small_groups gtky_is_leader gtky_leader gtky_is_follower gtky_friends gtky_hesitant
       gtky_active gtky_reserved gtky_boundaries gtky_authority gtky_adapts gtky_allergies med_allergies
       food_allergies other_allergies health_concerns asthma migraines severe_allergy anorexia diabetes
-      altitude concerns_misc cs_vip_meds cs_vip_dev cs_vip_strengths cs_vip_challenges
-      cs_vip_mobility cs_vip_walk cs_vip_comm_addl cs_vip_comm_small cs_vip_comm_large
-      cs_vip_comm_directions cs_vip_stress_addl cs_vip_stress_behavior
-      cs_vip_calm cs_vip_sitting cs_vip_hobby cs_vip_buddy cs_vip_addl_info
+      altitude concerns_misc cs_vip_meds cs_vip_dev cs_vip_strengths cs_vip_challenges cs_restrictions
+      cs_vip_mobility cs_vip_walk cs_vip_comm_addl cs_vip_comm_small cs_vip_comm_large cs_other_special_needs
+      cs_vip_comm_directions cs_vip_stress_addl cs_vip_stress_behavior cs_medications cs_vip_staff_administered_meds
+      cs_vip_calm cs_vip_sitting cs_vip_hobby cs_vip_buddy cs_vip_addl_info crustu_forms_acknowledged cs_chronic_health_addl
+      cs_restriction_certified cs_vip_developmental_age
     ] << CruStudentMedicalHistory.multi_selection_collections.transform_values { |_| [] },
     meal_exemptions_attributes: %i[
       id _destroy date meal_type

--- a/app/admin/family.rb
+++ b/app/admin/family.rb
@@ -54,7 +54,7 @@ ActiveAdmin.register Family do
       filename: import_params[:file].path
     )
   
-    ImportPeopleFromSpreadsheetJob.perform_now(job.id)
+    ImportPeopleFromSpreadsheetJob.perform_later(job.id)
   
     redirect_to job
   end

--- a/app/admin/family.rb
+++ b/app/admin/family.rb
@@ -46,17 +46,19 @@ ActiveAdmin.register Family do
 
   collection_action :import_spreadsheet, method: :post do
     return head :forbidden unless authorized?(:import, Family)
-
-    import_params =
-      ActionController::Parameters.new(params).require(:import_spreadsheet).
-        permit(:file)
-
-    job = UploadJob.create!(user_id: current_user.id,
-                            filename: import_params[:file].path)
-    ImportPeopleFromSpreadsheetJob.perform_later(job.id)
-
+  
+    import_params = params.require(:import_spreadsheet).permit(:file)
+  
+    job = UploadJob.create!(
+      user_id: current_user.id,
+      filename: import_params[:file].path
+    )
+  
+    ImportPeopleFromSpreadsheetJob.perform_now(job.id)
+  
     redirect_to job
   end
+  
 
   action_item :accounting_report, only: %i[show edit] do
     link_to 'Accounting Report', family_accounting_reports_path(family)

--- a/app/admin/housing_facility.rb
+++ b/app/admin/housing_facility.rb
@@ -30,9 +30,7 @@ ActiveAdmin.register HousingFacility  do
   collection_action :import_spreadsheet, method: :post do
     return head :forbidden unless authorized?(:import, HousingFacility)
 
-    import_params =
-      ActionController::Parameters.new(params).require('import_spreadsheet').
-        permit(:file, :skip_first)
+    import_params = params.require('import_spreadsheet').permit(:file, :skip_first)
 
     job = UploadJob.create!(user_id: current_user.id,
                             filename: import_params[:file].path)

--- a/app/admin/ministry.rb
+++ b/app/admin/ministry.rb
@@ -15,9 +15,7 @@ ActiveAdmin.register Ministry do
   collection_action :import_ministries, method: :post do
     return head :forbidden unless authorized?(:import, Ministry)
 
-    import_params =
-      ActionController::Parameters.new(params).
-        require(:spreadsheet_import_ministries).permit(:file, :skip_first)
+    import_params = params.require(:spreadsheet_import_ministries).permit(:file, :skip_first)
 
     job = UploadJob.create!(user_id: current_user.id,
                             filename: import_params[:file].path)
@@ -30,9 +28,7 @@ ActiveAdmin.register Ministry do
   collection_action :import_hierarchy, method: :post do
     return head :forbidden unless authorized?(:import, Ministry)
 
-    import_params =
-      ActionController::Parameters.new(params).
-        require(:spreadsheet_import_hierarchy).permit(:file, :skip_first)
+    import_params = params.require(:spreadsheet_import_hierarchy).permit(:file, :skip_first)
 
     job = UploadJob.create!(user_id: current_user.id,
                             filename: import_params[:file].path)

--- a/app/assets/javascripts/active_admin.js
+++ b/app/assets/javascripts/active_admin.js
@@ -28,9 +28,9 @@
 //= require widgets/index-per-page-selector
 //
 //  Telephone Numbers ------------------
-//= require intlTelInput
-//= require libphonenumber/utils
-//= require widgets/intl-tel-input-rails
+// require intlTelInput
+// require libphonenumber/utils
+// require widgets/intl-tel-input-rails
 //
 //  Money ------------------------------
 //= require jquery.price_format.2.0
@@ -72,6 +72,7 @@
 //= require acts_as_list/reorder
 
 //  Fetch data for housing lists (this is needed on multiple pages)
+console.log('Loading housing unit hierarchy and families');
 window.$menu_loaded = $.get('/housing_units_list', function(data) {
   window.$housing_unit_hierarchy = data.housing;
   return window.$housing_families = data.families;

--- a/app/assets/javascripts/housing/housing.js
+++ b/app/assets/javascripts/housing/housing.js
@@ -49,14 +49,24 @@ $(function() {
   });
 
   // When new Stay fields are added
-  return $(containerSelector).on('DOMNodeInserted', function(event) {
-    const $container = $(event.target);
-    if ($(event.target).is(`${containerSelector} ${itemSelector}`)) {
-      setupDynamicFields($container, true);
-      setupNewStayDefaults($container);
-      return setupDurationCalculation($container);
-    }
+  const housingObserver = new MutationObserver(function(mutations) {
+    mutations.forEach(function(mutation) {
+      mutation.addedNodes.forEach(function(node) {
+        if (node.nodeType === 1 && $(node).is(`${containerSelector} ${itemSelector}`)) {
+          const $container = $(node);
+          setupDynamicFields($container, true);
+          setupNewStayDefaults($container);
+          setupDurationCalculation($container);
+        }
+      });
+    });
   });
+
+  const container = document.querySelector(containerSelector);
+  if (container) {
+    housingObserver.observe(container, { childList: true, subtree: true });
+  }
+
 });
 
 var setupHousingDefaults = function($container) {

--- a/app/assets/javascripts/person/course_attendance_form.js
+++ b/app/assets/javascripts/person/course_attendance_form.js
@@ -14,9 +14,19 @@ var setupCourseAttendanceForm = function() {
   if (!$form.length) { return; }
 
 
-  return $('body').on('DOMNodeInserted', function(event) {
-    if ($(event.target).is(`${containerSelectormain} ${itemSelectorMain}`)) {
-      return $(event.target).find('select').chosen({width: '80%'});
-    }
+  const courseAttendanceObserver = new MutationObserver(function(mutations) {
+  mutations.forEach(function(mutation) {
+    mutation.addedNodes.forEach(function(node) {
+      if (node.nodeType === 1 && $(node).is(`${containerSelectormain} ${itemSelectorMain}`)) {
+        $(node).find('select').chosen({ width: '80%' });
+      }
+    });
   });
+});
+
+const container = document.querySelector('body'); // or limit to a more specific container if possible
+if (container) {
+  courseAttendanceObserver.observe(container, { childList: true, subtree: true });
+}
+
 };

--- a/app/assets/javascripts/widgets/chosen-jquery.js
+++ b/app/assets/javascripts/widgets/chosen-jquery.js
@@ -4,9 +4,29 @@
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/main/docs/suggestions.md
  */
 $(function() {
-  $('body').on('DOMNodeInserted', event => setupChosenWidget(event.target));
-  return setupChosenWidget(document);
+  function setupWidgetIfNeeded(node) {
+    // Only act on elements, not text nodes, etc.
+    if (node.nodeType === 1) {
+      setupChosenWidget(node);
+    }
+  }
+
+  // Initialize on existing document
+  setupChosenWidget(document);
+
+  // Use MutationObserver to detect future inserts
+  const chosenObserver = new MutationObserver(mutations => {
+    mutations.forEach(mutation => {
+      mutation.addedNodes.forEach(setupWidgetIfNeeded);
+    });
+  });
+
+  chosenObserver.observe(document.body, {
+    childList: true,
+    subtree: true
+  });
 });
+
 
 
 var setupChosenWidget = scope => $('select', scope).each( function() {

--- a/app/assets/javascripts/widgets/ckeditor.js
+++ b/app/assets/javascripts/widgets/ckeditor.js
@@ -75,7 +75,34 @@ const setupCkeditor = function() {
 };
 
 $(function() {
-  $('body').on('DOMNodeInserted', event => $('.ckeditor_input', event.target).each(setupCkeditor));
+  function initializeCkeditorOn(node) {
+    if (node.nodeType !== 1) return;
 
-  return $('.ckeditor_input').each(setupCkeditor);
+    // Handle the node itself if it matches
+    if ($(node).is('.ckeditor_input')) {
+      setupCkeditor.call(node);
+    }
+
+    // Handle any matching descendants
+    $(node).find('.ckeditor_input').each(function() {
+      setupCkeditor.call(this);
+    });
+  }
+
+  // Initialize on existing elements
+  $('.ckeditor_input').each(function() {
+    setupCkeditor.call(this);
+  });
+
+  // Watch for future inserts
+  const ckeObserver = new MutationObserver(mutations => {
+    mutations.forEach(mutation => {
+      mutation.addedNodes.forEach(initializeCkeditorOn);
+    });
+  });
+
+  ckeObserver.observe(document.body, {
+    childList: true,
+    subtree: true
+  });
 });

--- a/app/assets/javascripts/widgets/price_format-jquery.js
+++ b/app/assets/javascripts/widgets/price_format-jquery.js
@@ -4,9 +4,32 @@
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/main/docs/suggestions.md
  */
 $(function() {
+  function initializeMoneyInput(node) {
+    if (node.nodeType !== 1) return;
+
+    // Handle if the inserted node itself is a money input
+    if ($(node).is('[data-money-input]')) {
+      setupPriceFormat(node);
+    }
+
+    // Handle any matching descendants
+    $(node).find('[data-money-input]').each((_, elem) => setupPriceFormat(elem));
+  }
+
+  // Run once on page load
   $('[data-money-input]').each((_, elem) => setupPriceFormat(elem));
 
-  return $('body').on('DOMNodeInserted', event => $(event.target).find('[data-money-input]').each((_, elem) => setupPriceFormat(elem)));
+  // Setup MutationObserver
+  const priceFormatObserver = new MutationObserver(mutations => {
+    mutations.forEach(mutation => {
+      mutation.addedNodes.forEach(initializeMoneyInput);
+    });
+  });
+
+  priceFormatObserver.observe(document.body, {
+    childList: true,
+    subtree: true
+  });
 });
 
 

--- a/app/assets/stylesheets/person/show.scss
+++ b/app/assets/stylesheets/person/show.scss
@@ -5,6 +5,12 @@
   table th{
     width: 200px;
   }
+  table tr.row-uuid td span{
+    color: white;
+    font-weight: bold;
+    background: gray;
+    padding: 3px;
+  }
 }
 
 .attendance-comment {

--- a/app/controllers/api_base_controller.rb
+++ b/app/controllers/api_base_controller.rb
@@ -1,0 +1,2 @@
+class ApiBaseController < ActionController::API
+end

--- a/app/controllers/external_forms_controller.rb
+++ b/app/controllers/external_forms_controller.rb
@@ -1,0 +1,82 @@
+class ExternalFormsController < ApiBaseController
+  before_action :validate_api_key  
+
+  def approve
+    handle_form_update(
+      uid: approve_params[:uid],
+      approval_state: true,
+      approved_by: 'external_api',
+      success_message: 'Form approved successfully.',
+      action: 'approved'
+    )
+  end
+
+  def disapprove
+    handle_form_update(
+      uid: disapprove_params[:uid],
+      approval_state: false,
+      approved_by: nil,
+      success_message: 'Form disapproved successfully.',
+      action: 'disapproved'
+    )
+  end
+
+  private
+
+  def validate_api_key
+    expected_api_key = Rails.application.credentials.external_api_key || ENV['EXTERNAL_API_KEY']
+    provided_api_key = request.query_parameters['apiKey']
+
+    unless ActiveSupport::SecurityUtils.secure_compare(provided_api_key.to_s, expected_api_key.to_s)
+      Rails.logger.warn(unauthorized_access_log(provided_api_key))
+      render json: { error: 'Unauthorized: Invalid or missing API key' }, status: :forbidden
+    end
+  end
+
+  def approve_params
+    params.permit(:uid)
+  end
+
+  def disapprove_params
+    params.permit(:uid)
+  end
+
+  def handle_form_update(uid:, approval_state:, approved_by:, success_message:, action:)
+    child = Child.find_by(uuid: uid)
+
+    unless child
+      Rails.logger.warn(child_not_found_log(uid))
+      return render json: { error: 'Child not found' }, status: :not_found
+    end
+
+    if child.update(forms_approved: approval_state, forms_approved_by: approved_by)
+      Rails.logger.info(success_log(child, uid, action))
+      render json: { message: success_message }
+    else
+      Rails.logger.error(failure_log(child, uid, action))
+      render json: { error: 'Unable to process form. Please try again later.' }, status: :unprocessable_entity
+    end
+  end
+
+  # Log message helpers
+
+  def child_not_found_log(uid)
+    "[ExternalFormsController] UID not found: #{uid}, IP: #{request.remote_ip}"
+  end
+
+  def unauthorized_access_log(provided_api_key)
+    "[ExternalFormsController] Unauthorized access attempt. " \
+    "IP: #{request.remote_ip}, Provided Key: #{provided_api_key.inspect}"
+  end
+
+  def success_log(child, uid, action)
+    "[ExternalFormsController] Form #{action} for child #{child.id} (#{uid}) " \
+    "by external API. IP: #{request.remote_ip}"
+  end
+
+  def failure_log(child, uid, action)
+    errors = child.errors.full_messages.join(', ')
+    "[ExternalFormsController] Failed to #{action} form for child #{child.id} (#{uid}). " \
+    "Errors: #{errors}. IP: #{request.remote_ip}"
+  end
+end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -43,7 +43,7 @@ class Child < Person
 
   class << self
     def childcare_grade_levels
-      GRADE_LEVELS.first(grade5_index + 1)
+      GRADE_LEVELS.first(grade6_index + 1)
     end
 
     def childcare_care_grade_levels
@@ -51,7 +51,7 @@ class Child < Person
     end
     
     def childcare_camp_grade_levels
-      (GRADE_LEVELS.first(grade5_index + 1) - GRADE_LEVELS.first(gradeAge5Kindergarten_index))
+      (GRADE_LEVELS.first(grade6_index + 1) - GRADE_LEVELS.first(gradeAge5Kindergarten_index))
     end
 
     def hot_lunch_grade_levels
@@ -59,11 +59,15 @@ class Child < Person
     end
 
     def senior_grade_levels
-      GRADE_LEVELS.last(GRADE_LEVELS.size - (grade5_index + 1))
+      GRADE_LEVELS.last(GRADE_LEVELS.size - (grade6_index + 1))
     end
 
     def grade5_index
       GRADE_LEVELS.index('grade5')
+    end
+
+    def grade6_index
+      GRADE_LEVELS.index('grade6')
     end
 
     def gradeAge5PreKindergarten_index

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 class Child < Person
   include FamilyMember
 
@@ -84,6 +85,18 @@ class Child < Person
 
     def age1_index
       GRADE_LEVELS.index('age1')
+    end
+
+    def kids_care_grades
+      GRADE_LEVELS.first(gradeAge5Kindergarten_index + 1)
+    end
+
+    def kids_camp_grades
+      GRADE_LEVELS[grade1_index..grade6_index]
+    end
+
+    def grade1_index
+      GRADE_LEVELS.index('grade1')
     end
   end
 
@@ -204,3 +217,4 @@ class Child < Person
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/models/childcare_medical_history.rb
+++ b/app/models/childcare_medical_history.rb
@@ -4,13 +4,16 @@ class ChildcareMedicalHistory < ApplicationRecord
 
   belongs_to :child
 
-  multi_selection_attributes chronic_health: ['Asthma', 'Diabetes', 'Severe allergy', 'Other'],
+  multi_selection_attributes chronic_health: ['Asthma', 'Diabetes', 'Epilepsy', 'Severe allergy', 'Other', 'None of the above'],
                              immunizations: ['Yes'],
-                             health_misc: ['Developmental delay', 'Behavioral challenges', 'Other special need',
-                                           'Disability', 'Extra assistance', 'Adaptive equipment', 'None of the above'], ## removed sensory Processing Disorder, added Other special need
+                             non_immunizations: ['Yes'],
+                             health_misc: ['Developmental delay', 'Other special need', 'Behavioral challenges', 'Disability',
+                             'Extra assistance', 'Adaptive equipment', 'None of the above', 'ADHD/ADD','Autism',
+                             'Down Syndrome', 'Extra assistance'], ## removed sensory Processing Disorder, added Other special need
                              vip_comm: ['In simple phrases', 'In complete sentences', 'Other'],## removed Visual schedule 
-                             vip_stress: ['Noisy spaces', 'Crowded spaces', 'Loud noises',
-                                          'Heights', 'Changing schedule', 'Other']
+                             vip_stress: ['Noisy spaces', 'Crowded spaces', 'Loud noises', 'Heights', 'Changing schedule', 'Other', 'None of the above'],
+                             cc_allergies: ['Eggs', 'Milk', 'Tree nuts', 'Fish/Shellfish', 'Peanuts', 'Wheat',
+                                       'Insect sting', 'Pollen', 'Medications', 'Latex', 'Soy', 'Other','None of the above']
 
   single_selection_attributes sunscreen_self: %w[Yes No],
                               sunscreen_assisted: %w[Yes No],

--- a/app/models/childcare_medical_history.rb
+++ b/app/models/childcare_medical_history.rb
@@ -7,8 +7,8 @@ class ChildcareMedicalHistory < ApplicationRecord
   multi_selection_attributes chronic_health: ['Asthma', 'Diabetes', 'Epilepsy', 'Severe allergy', 'Other', 'None of the above'],
                              immunizations: ['Yes'],
                              non_immunizations: ['Yes'],
-                             health_misc: ['Developmental delay', 'Other special need', 'Behavioral challenges', 'Disability',
-                             'Extra assistance', 'Adaptive equipment', 'None of the above', 'ADHD/ADD','Autism',
+                             health_misc: ['Developmental delay', 'Other', 'Behavioral challenges', 'Disability',
+                             'Extra assistance', 'Adaptive equipment', 'None of the above', 'ADHD','Autism',
                              'Down Syndrome', 'Extra assistance'], ## removed sensory Processing Disorder, added Other special need
                              vip_comm: ['In simple phrases', 'In complete sentences', 'Other'],## removed Visual schedule 
                              vip_stress: ['Noisy spaces', 'Crowded spaces', 'Loud noises', 'Heights', 'Changing schedule', 'Other', 'None of the above'],

--- a/app/models/childcare_medical_history.rb
+++ b/app/models/childcare_medical_history.rb
@@ -13,5 +13,6 @@ class ChildcareMedicalHistory < ApplicationRecord
                              vip_stress: ['Noisy spaces', 'Crowded spaces', 'Loud noises', 'Heights', 'Changing schedule', 'Other', 'None of the above'],
                              cc_allergies: ['Eggs', 'Milk', 'Tree nuts', 'Fish/Shellfish', 'Peanuts', 'Wheat',
                                        'Insect sting', 'Pollen', 'Medications', 'Latex', 'Soy', 'Other','None of the above']
+  single_selection_attributes cc_restriction_certified: %w[CruKids_certify_WITHres CruKids_certify_NOres]
                               
 end

--- a/app/models/childcare_medical_history.rb
+++ b/app/models/childcare_medical_history.rb
@@ -7,15 +7,11 @@ class ChildcareMedicalHistory < ApplicationRecord
   multi_selection_attributes chronic_health: ['Asthma', 'Diabetes', 'Epilepsy', 'Severe allergy', 'Other', 'None of the above'],
                              immunizations: ['Yes'],
                              non_immunizations: ['Yes'],
-                             health_misc: ['Developmental delay', 'Other', 'Behavioral challenges', 'Disability',
-                             'Extra assistance', 'Adaptive equipment', 'None of the above', 'ADHD','Autism',
-                             'Down Syndrome', 'Extra assistance'], ## removed sensory Processing Disorder, added Other special need
+                             health_misc: ['ADHD', 'Adaptive equipment', 'Autism', 'Behavioral challenges', 'Developmental delay',
+                             'Down Syndrome', 'Extra assistance', 'Other', 'None of the above'],
                              vip_comm: ['In simple phrases', 'In complete sentences', 'Other'],## removed Visual schedule 
                              vip_stress: ['Noisy spaces', 'Crowded spaces', 'Loud noises', 'Heights', 'Changing schedule', 'Other', 'None of the above'],
                              cc_allergies: ['Eggs', 'Milk', 'Tree nuts', 'Fish/Shellfish', 'Peanuts', 'Wheat',
                                        'Insect sting', 'Pollen', 'Medications', 'Latex', 'Soy', 'Other','None of the above']
-
-  single_selection_attributes sunscreen_self: %w[Yes No],
-                              sunscreen_assisted: %w[Yes No],
-                              sunscreen_provided: %w[Yes No]
+                              
 end

--- a/app/models/cru_student_medical_history.rb
+++ b/app/models/cru_student_medical_history.rb
@@ -6,11 +6,14 @@ class CruStudentMedicalHistory < ApplicationRecord
 
   multi_selection_attributes gtky_challenges: ['Death', 'Divorce', 'Abuse', 'Anger issues', 'Anxiety', 'Eating disorder',
                                                'Major life change', 'Depression', 'Significant bullying', 'Behavioral issues',
-                                               'Self harm', 'Bipolar disorder', 'Foster Adoption', 'Other'],
+                                               'Self harm', 'Bipolar disorder', 'Foster Adoption', 'Other', 'None of the above'],
                              cs_health_misc: ['Developmental delay', 'Other special need', 'Behavioral challenges', 'Disability',
                                               'Extra assistance', 'Adaptive equipment', 'None of the above'], ## removed Sensory issues, added Other special need
                              cs_vip_comm: ['In simple phrases', 'In complete sentences', 'Other'],
-                             cs_vip_stress: ['Noisy spaces', 'Crowded spaces', 'Loud noises', 'Other']
+                             cs_vip_stress: ['Noisy spaces', 'Crowded spaces', 'Loud noises', 'Other'],
+                             cs_allergies: ['Eggs', 'Milk', 'Tree nuts', 'Fish/Shellfish', 'Peanuts', 'Wheat',
+                                            'Insect sting', 'Pollen', 'Medications', 'Latex', 'Soy', 'Other', 'None of the above'],
+                             cs_chronic_health: ['Asthma', 'Anorexia', 'Diabetes', 'Migraine', 'Epilepsy', 'Severe allergy', 'Other', 'None of the above']
 
   single_selection_attributes gtky_lunch: ['YES lunch on their own', 'NO lunch on their own'],
                               gtky_signout: ['YES self sign out', 'NO self sign out'],

--- a/app/models/cru_student_medical_history.rb
+++ b/app/models/cru_student_medical_history.rb
@@ -7,19 +7,21 @@ class CruStudentMedicalHistory < ApplicationRecord
   multi_selection_attributes gtky_challenges: ['Death', 'Divorce', 'Abuse', 'Anger issues', 'Anxiety', 'Eating disorder',
                                                'Major life change', 'Depression', 'Significant bullying', 'Behavioral issues',
                                                'Self harm', 'Bipolar disorder', 'Foster Adoption', 'Other', 'None of the above'],
-                             cs_health_misc: ['Developmental delay', 'Other', 'Behavioral challenges', 'Disability',
-                                              'Extra assistance', 'Adaptive equipment', 'None of the above', 'ADHD', 'Autism', 'Down Syndrome'],
+                             cs_health_misc: ['ADHD', 'Adaptive equipment', 'Autism', 'Behavioral challenges', 'Developmental delay',
+                                              'Down Syndrome', 'Extra assistance', 'Other', 'None of the above'],
                              cs_vip_comm: ['In simple phrases', 'In complete sentences', 'Other'],
                              cs_vip_stress: ['Noisy spaces', 'Crowded spaces', 'Loud noises', 'Heights', 'Changing schedule', 'Other', 'None of the above'],
                              cs_allergies: ['Eggs', 'Milk', 'Tree nuts', 'Fish/Shellfish', 'Peanuts', 'Wheat',
                                             'Insect sting', 'Pollen', 'Medications', 'Latex', 'Soy', 'Other', 'None of the above'],
-                             cs_chronic_health: ['Asthma', 'Anorexia', 'Diabetes', 'Migraines', 'Epilepsy', 'Severe allergy', 'Other', 'None of the above']
+                             cs_chronic_health: ['Asthma', 'Anorexia', 'Diabetes', 'Migraines', 'Epilepsy', 'Severe allergy', 'Other', 'None of the above'],
+                             cs_restriction_certified: %w[CruKids_certify_WITHres CruKids_certify_NOres]
 
   single_selection_attributes gtky_lunch: ['YES lunch on their own', 'NO lunch on their own'],
-                              gtky_signout: ['YES self sign out', 'NO self sign out', 'YES', 'NO'],
+                              gtky_signout: %w[YES NO],
                               gtky_sibling: %w[Yes No],
                               gtky_leader: %w[Yes No],
                               gtky_musical: %w[Yes No],
                               gtky_allergies: %w[Yes No],
-                              health_concerns: %w[Yes No]
+                              health_concerns: %w[Yes No],
+                              crustu_forms_acknowledged: %w[Yes No]
 end

--- a/app/models/cru_student_medical_history.rb
+++ b/app/models/cru_student_medical_history.rb
@@ -13,8 +13,7 @@ class CruStudentMedicalHistory < ApplicationRecord
                              cs_vip_stress: ['Noisy spaces', 'Crowded spaces', 'Loud noises', 'Heights', 'Changing schedule', 'Other', 'None of the above'],
                              cs_allergies: ['Eggs', 'Milk', 'Tree nuts', 'Fish/Shellfish', 'Peanuts', 'Wheat',
                                             'Insect sting', 'Pollen', 'Medications', 'Latex', 'Soy', 'Other', 'None of the above'],
-                             cs_chronic_health: ['Asthma', 'Anorexia', 'Diabetes', 'Migraines', 'Epilepsy', 'Severe allergy', 'Other', 'None of the above'],
-                             cs_restriction_certified: %w[CruKids_certify_WITHres CruKids_certify_NOres]
+                             cs_chronic_health: ['Asthma', 'Anorexia', 'Diabetes', 'Migraines', 'Epilepsy', 'Severe allergy', 'Other', 'None of the above']
 
   single_selection_attributes gtky_lunch: ['YES lunch on their own', 'NO lunch on their own'],
                               gtky_signout: %w[YES NO],
@@ -23,5 +22,6 @@ class CruStudentMedicalHistory < ApplicationRecord
                               gtky_musical: %w[Yes No],
                               gtky_allergies: %w[Yes No],
                               health_concerns: %w[Yes No],
-                              crustu_forms_acknowledged: %w[Yes No]
+                              crustu_forms_acknowledged: %w[Yes No],
+                              cs_restriction_certified: %w[CruKids_certify_WITHres CruKids_certify_NOres]
 end

--- a/app/models/cru_student_medical_history.rb
+++ b/app/models/cru_student_medical_history.rb
@@ -7,16 +7,16 @@ class CruStudentMedicalHistory < ApplicationRecord
   multi_selection_attributes gtky_challenges: ['Death', 'Divorce', 'Abuse', 'Anger issues', 'Anxiety', 'Eating disorder',
                                                'Major life change', 'Depression', 'Significant bullying', 'Behavioral issues',
                                                'Self harm', 'Bipolar disorder', 'Foster Adoption', 'Other', 'None of the above'],
-                             cs_health_misc: ['Developmental delay', 'Other special need', 'Behavioral challenges', 'Disability',
-                                              'Extra assistance', 'Adaptive equipment', 'None of the above'], ## removed Sensory issues, added Other special need
+                             cs_health_misc: ['Developmental delay', 'Other', 'Behavioral challenges', 'Disability',
+                                              'Extra assistance', 'Adaptive equipment', 'None of the above', 'ADHD', 'Autism', 'Down Syndrome'],
                              cs_vip_comm: ['In simple phrases', 'In complete sentences', 'Other'],
-                             cs_vip_stress: ['Noisy spaces', 'Crowded spaces', 'Loud noises', 'Other'],
+                             cs_vip_stress: ['Noisy spaces', 'Crowded spaces', 'Loud noises', 'Heights', 'Changing schedule', 'Other', 'None of the above'],
                              cs_allergies: ['Eggs', 'Milk', 'Tree nuts', 'Fish/Shellfish', 'Peanuts', 'Wheat',
                                             'Insect sting', 'Pollen', 'Medications', 'Latex', 'Soy', 'Other', 'None of the above'],
-                             cs_chronic_health: ['Asthma', 'Anorexia', 'Diabetes', 'Migraine', 'Epilepsy', 'Severe allergy', 'Other', 'None of the above']
+                             cs_chronic_health: ['Asthma', 'Anorexia', 'Diabetes', 'Migraines', 'Epilepsy', 'Severe allergy', 'Other', 'None of the above']
 
   single_selection_attributes gtky_lunch: ['YES lunch on their own', 'NO lunch on their own'],
-                              gtky_signout: ['YES self sign out', 'NO self sign out'],
+                              gtky_signout: ['YES self sign out', 'NO self sign out', 'YES', 'NO'],
                               gtky_sibling: %w[Yes No],
                               gtky_leader: %w[Yes No],
                               gtky_musical: %w[Yes No],

--- a/app/models/housing_unit.rb
+++ b/app/models/housing_unit.rb
@@ -20,8 +20,8 @@ class HousingUnit < ApplicationRecord
     where(housing_facility: HousingFacility.where(cafeteria: cafe))
   end)
 
-  scope :natural_order_asc, -> { order(natural_order) }
-  scope :natural_order_desc, -> { order(natural_order(:desc)) }
+  scope :natural_order_asc, -> { order(Arel.sql(natural_order)) }
+  scope :natural_order_desc, -> { order(Arel.sql(natural_order(:desc))) }
 
   class << self
     def hierarchy

--- a/app/models/import/person.rb
+++ b/app/models/import/person.rb
@@ -91,8 +91,7 @@ module Import
       immunizations: 'Forms CC MH Immunizations',
       non_immunizations: 'Forms CC MH non-immunized',
       health_misc: 'Forms CC MH Health Misc',
-      restrictions: 'Forms CC MH Restrictions',
-      medications_by_staff: 'Forms CC MH MedicationsByStaff',
+      restrictions: 'Forms CC MH Restrictions',    
       crustu_forms_acknowledged: 'crustu_forms_acknowledged',
       cc_other_special_needs: 'Forms CC MH Special Needs',
 
@@ -103,7 +102,7 @@ module Import
       vip_challenges: 'Forms CC VIP Challenges',
       vip_mobility: 'Forms CC VIP Mobility',
       # vip_walk: 'Forms CC VIP Walk',
-      cc_vip_developmental_age: 'Forms CS VIP child_dev_age',
+      cc_vip_developmental_age: 'Forms CC VIP child_dev_age',
       cc_vip_staff_administered_meds: 'Forms CC MH MedicationsByStaff',
       # vip_comm: 'Forms CC VIP Comm',
       # vip_comm_addl: 'Forms CC VIP Comm Addl',
@@ -125,8 +124,7 @@ module Import
     
       # parent_agree: 'Forms CS ParentAgree',
       # gtky_lunch: 'Forms CS GTKY Lunch',
-      cs_chronic_health: 'Forms CS MH Chronic Health',
-      cs_medications_by_staff: 'Forms CS MH MedicationsByStaff',
+      cs_chronic_health: 'Forms CS MH Chronic Health',      
       cs_other_special_needs: 'Forms CS MH Special Needs',
       cs_restriction_certified: 'Forms CS MH Certify',
       cs_restrictions: 'Forms CS MH Restrictions',

--- a/app/models/import/person.rb
+++ b/app/models/import/person.rb
@@ -59,7 +59,8 @@ module Import
     
       grade_level: 'Age Group',
       needs_bed: 'Child Needs Dorm Bed',
-      # childcare_deposit: 'Cru Kids Deposit',
+      childcare_late_fee: 'Cru Kids Late Fee',
+      childcare_cancellation_fee: 'Cru Kids Cancellation Fee',
       childcare_weeks: 'Child Program Weeks',
       hot_lunch_weeks: 'Hot Lunch Weeks',
       childcare_comment: 'Cru Kids Comments',
@@ -283,6 +284,14 @@ module Import
       @needs_bed = true_string?(str)
     end
 
+    def childcare_late_fee=(str)
+      @childcare_late_fee = true_string?(str)
+    end
+
+    def childcare_cancellation_fee=(str)
+      @childcare_cancellation_fee = true_string?(str)
+    end
+    
     def grade_level=(group)
       @grade_level =
         if (match = AGE_GROUPS[group])

--- a/app/models/import/person.rb
+++ b/app/models/import/person.rb
@@ -94,7 +94,7 @@ module Import
       restrictions: 'Forms CC MH Restrictions',
       medications_by_staff: 'Forms CC MH MedicationsByStaff',
       crustu_forms_acknowledged: 'crustu_forms_acknowledged',
-      other_special_needs: 'Forms CC MH Special Needs',
+      cc_other_special_needs: 'Forms CC MH Special Needs',
 
       # CC VIP
       # vip_meds: 'Forms CC VIP Meds',
@@ -170,7 +170,7 @@ module Import
       # anorexia: 'Forms CS MH Anorexia',
       # diabetes: 'Forms CS MH Diabetes',
       # altitude: 'Forms CS MH Altitude',
-      concerns_misc: 'Forms CS MH Chronic Health Addl',
+      cs_chronic_health_addl: 'Forms CS MH Chronic Health Addl',
       cs_health_misc: 'Forms CS MH Health Misc',
       # cs_vip_meds: 'Forms CS VIP Meds',
       # cs_vip_dev: 'Forms CS VIP Dev',

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -16,7 +16,7 @@ class Person < ApplicationRecord
   }.freeze
 
   has_paper_trail
-
+  before_create :assign_uuid
   belongs_to :family, inverse_of: :people, required: true
   belongs_to :ministry, optional: true
   belongs_to :spouse, class_name: 'Person', optional: true
@@ -140,5 +140,9 @@ class Person < ApplicationRecord
     if family.primary_person_id.blank? && is_a?(Attendee)
       family.update!(primary_person_id: id)
     end
+  end
+
+  def assign_uuid
+    self.uuid ||= SecureRandom.uuid
   end
 end

--- a/app/services/childcare/send_docusign_envelope.rb
+++ b/app/services/childcare/send_docusign_envelope.rb
@@ -157,15 +157,15 @@ class Childcare::SendDocusignEnvelope < ApplicationService
         value: recipient&.spouse&.phone
       },
       {
-        label: 'Parent2Email',
+        label: '\\*Parent2Email',
         value: recipient&.spouse&.email
       },
       {
-        label: 'Parent1Ministry',
+        label: '\\*Parent1Ministry',
         value: recipient.main_ministry&.name
       },
       {
-        label: 'Parent1Cohort',
+        label: '\\*Parent1Cohort',
         value: get_cohort_for(recipient)
       },
       {
@@ -185,19 +185,19 @@ class Childcare::SendDocusignEnvelope < ApplicationService
         value: child.family&.state
       },
       {
-        label: 'HomeAddress',
+        label: '\\*HomeAddress',
         value: get_full_address(child.family)
       },
       {
-        label: 'Gender',
+        label: '\\*Gender',
         value: get_gender_formatted(child.gender)
       },
       {
-        label: 'ChildGender',
+        label: '\\*ChildGender',
         value:  get_gender_formatted(child.gender)
       },
       {
-        label: 'Parent1Email',
+        label: '\\*Parent1Email',
         value: recipient.email
       }
     ]
@@ -303,7 +303,7 @@ class Childcare::SendDocusignEnvelope < ApplicationService
         value: mh.chronic_health_addl
       },
       {
-        label: 'Forms-CC-MH-AllMeds',
+        label: '\\*Forms-CC-MH-AllMeds',
         value: mh.medications
       },      
       {
@@ -385,7 +385,7 @@ class Childcare::SendDocusignEnvelope < ApplicationService
         value: mh.vip_meds
       },
       {
-        label: 'Forms-CC-VIP-DevAge',
+        label: '\\*Forms-CC-VIP-DevAge',
         value: mh.cc_vip_developmental_age
       },
       {
@@ -493,7 +493,7 @@ class Childcare::SendDocusignEnvelope < ApplicationService
         value: mh.vip_addl_info
       },
       {
-        label: 'Forms-CC-MH-StaffAdministeredMeds',
+        label: '\\*Forms-CC-MH-StaffAdministeredMeds',
         value: mh.cc_vip_staff_administered_meds
       }
     ]

--- a/app/services/childcare/send_docusign_envelope.rb
+++ b/app/services/childcare/send_docusign_envelope.rb
@@ -151,27 +151,7 @@ class Childcare::SendDocusignEnvelope < ApplicationService
       {
         label: 'ChildPreferredFullName',
         value: "#{child.name_tag_first_name} #{child.name_tag_last_name}"
-      },
-      #{
-      #   label: 'Week1',
-      #   value: check_if_in_list(child.childcare_weeks, 0)
-      # },
-      # {
-      #   label: 'Week2',
-      #   value: check_if_in_list(child.childcare_weeks, 1)
-      # },
-      # {
-      #   label: 'Week3',
-      #   value: check_if_in_list(child.childcare_weeks, 2)
-      # },
-      # {
-      #   label: 'Week4',
-      #   value: check_if_in_list(child.childcare_weeks, 3)
-      # },
-      # {
-      #   label: 'SC',
-      #   value: check_if_in_list(child.childcare_weeks, 4)
-      # },
+      },      
       {
         label: '\\*Parent1FullName',
         value: recipient.full_name(skip_middle: true)
@@ -210,7 +190,7 @@ class Childcare::SendDocusignEnvelope < ApplicationService
       },
       {
         label: '\\*HomeCounty',
-        value: child.family&.county
+        value: get_county(child)
       },
       {
         label: '\\*HomeState',
@@ -347,12 +327,12 @@ class Childcare::SendDocusignEnvelope < ApplicationService
         value: checkmark_if_yes(mh.non_immunizations&.join)
       },
       {
-        label: 'Forms-CC-MH-Certify-No',
-        value: checkmark_if_no(mh.cc_restriction_certified&.join)
+        label: 'Forms-CC-MH-Certify-No',        
+        value: checkmark_if_value(mh.cc_restriction_certified, 'CruKids_certify_NOres')
       },
       {
         label: 'Forms-CC-MH-Certify-Yes',
-        value: checkmark_if_yes(mh.cc_restriction_certified&.join)
+        value: checkmark_if_value(mh.cc_restriction_certified, 'CruKids_certify_WITHres')
       },
       {
         label: 'Forms-CC-MH-Certify-Restrictions',
@@ -364,7 +344,7 @@ class Childcare::SendDocusignEnvelope < ApplicationService
       },
       {
         label: 'Forms-CC-MH-Health-Misc-ADHD',
-        value: check_if_in_list(mh.health_misc, 'ADHD/ADD')
+        value: check_if_in_list(mh.health_misc, 'ADHD')
       },
       {
         label: 'Forms-CC-MH-Health-Misc-Developmental-delay',
@@ -372,7 +352,7 @@ class Childcare::SendDocusignEnvelope < ApplicationService
       },
       {
         label: 'Forms-CC-MH-Health-Misc-Other-special-need',
-        value: check_if_in_list(mh.health_misc, 'Other special need')
+        value: check_if_in_list(mh.health_misc, 'Other')
       },
       {
         label: 'Forms-CC-MH-Health-Misc-Behavioral-challenges',
@@ -380,7 +360,7 @@ class Childcare::SendDocusignEnvelope < ApplicationService
       },
       {
         label: 'Forms-CC-MH-Health-Misc-Autism',
-        value: check_if_in_list(mh.health_misc, 'Disability')
+        value: check_if_in_list(mh.health_misc, 'Autism')
       },
       {
         label: 'Forms-CC-MH-Health-Misc-Extra-assistance',
@@ -396,7 +376,7 @@ class Childcare::SendDocusignEnvelope < ApplicationService
       },
       {
         label: 'Forms-CC-MH-Health-Misc-Other',
-        value: check_if_in_list(mh.health_misc, 'Other special need')
+        value: check_if_in_list(mh.health_misc, 'Other')
       },
       {
         label: 'Forms-CC-MH-Health-Misc-OtherSpecialNeeds',
@@ -798,7 +778,7 @@ class Childcare::SendDocusignEnvelope < ApplicationService
       },
       {
         label: 'Forms-CS-MH-Chronic-Migraine',
-        value: check_if_in_list(smh.cs_chronic_health, 'Migraine')
+        value: check_if_in_list(smh.cs_chronic_health, 'Migraines')
       },
       {
         label: 'Forms-CS-MH-Chronic-SevereAllergy',
@@ -866,7 +846,7 @@ class Childcare::SendDocusignEnvelope < ApplicationService
       },
       {
         label: 'Forms-CS-MH-Health-Misc-ADHD',
-        value: check_if_in_list(smh.cs_health_misc, 'ADHD/ADD')
+        value: check_if_in_list(smh.cs_health_misc, 'ADHD')
       },
       {
         label: 'Forms-CS-MH-Health-Misc-DownSyndrome',
@@ -886,11 +866,11 @@ class Childcare::SendDocusignEnvelope < ApplicationService
       },
       {
         label: 'Forms-CS-MH-Certify-No',
-        value: checkmark_if_no(smh.cs_restriction_certified&.join)
+        value: checkmark_if_value(smh.cs_restriction_certified, 'CruKids_certify_NOres')
       },
       {
         label: 'Forms-CS-MH-Certify-Yes',
-        value: checkmark_if_yes(smh.cs_restriction_certified&.join)
+        value: checkmark_if_value(smh.cs_restriction_certified, 'CruKids_certify_WITHres')
       },
       {
         label: 'Forms-CS-MH-Certify-Restrictions',
@@ -1090,5 +1070,15 @@ class Childcare::SendDocusignEnvelope < ApplicationService
 
     attribute.include?('NO') ? 'X' : ''
   end
+
+  def checkmark_if_value(attribute, expected_value)
+    return '' if attribute.blank?
+
+    attribute.to_s.casecmp(expected_value.to_s).zero? ? 'X' : ''
+  end
+
+  def get_county(child)
+    child.county.presence || child.family&.county
+  end 
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/services/childcare/send_docusign_envelope.rb
+++ b/app/services/childcare/send_docusign_envelope.rb
@@ -4,10 +4,12 @@ class Childcare::SendDocusignEnvelope < ApplicationService
 
   SendEnvelopeError = Class.new(StandardError)
 
-  CARECAMP_VIP_TEMPLATE   = '22320162-2bfe-48c4-85b0-58415402a522'.freeze
-  CARECAMP_TEMPLATE       = 'eb24252c-5765-4231-9c0e-88f977e38b4b'.freeze
-  CRUSTU_VIP_TEMPLATE     = '2f34b10b-e87e-4f2d-82c3-20a4e82b7a8a'.freeze
-  CRUSTU_TEMPLATE         = 'd0325321-708b-42d3-a151-8b86089236e3'.freeze
+  KIDS_CARE_WITH_VIP_TEMPLATE = 'c836796a-ad75-4dcb-b132-402b031f70dc'.freeze
+  KIDS_CARE_NO_VIP_TEMPLATE   = 'e92627a4-2865-4b81-8de0-6db9f3517576'.freeze
+  KIDS_CAMP_WITH_VIP_TEMPLATE = '97ef9609-036b-4d9c-8343-5bec92ea734d'.freeze
+  KIDS_CAMP_NO_VIP_TEMPLATE   = '817f4a90-d6f4-4d7a-9500-62e4c0a1f8da'.freeze
+  CRUSTU_WITH_VIP_TEMPLATE    = '9e86bc46-fe68-499f-891c-c02bd59ab972'.freeze
+  CRUSTU_NO_VIP_TEMPLATE      = '59f3c410-1072-483a-94de-b7c3f06b032d'.freeze
   TEST_RECIPIENT          = 'Cru22KidsForms+DocuSignTesting@cru.org'.freeze
   TRACKING_COPY_RECIPIENT = 'Cru22KidsForms+DocuSignVoid@cru.org'.freeze
   attr_reader :recipient, :child, :note
@@ -82,14 +84,12 @@ class Childcare::SendDocusignEnvelope < ApplicationService
 
   # rubocop:disable Metrics/PerceivedComplexity
   def determine_docusign_template
-    if childcare_grade? && childcare_no_misc_health?
-      CARECAMP_TEMPLATE
-    elsif childcare_grade?
-      CARECAMP_VIP_TEMPLATE
-    elsif senior_grade? && senior_no_misc_health?
-      CRUSTU_TEMPLATE
+    if childcare_grade?
+      childcare_no_misc_health? ? KIDS_CARE_NO_VIP_TEMPLATE : KIDS_CARE_WITH_VIP_TEMPLATE
+    elsif childcare_camp_grade?
+      childcare_no_misc_health? ? KIDS_CAMP_NO_VIP_TEMPLATE : KIDS_CAMP_WITH_VIP_TEMPLATE
     elsif senior_grade?
-      CRUSTU_VIP_TEMPLATE
+      senior_no_misc_health? ? CRUSTU_NO_VIP_TEMPLATE : CRUSTU_WITH_VIP_TEMPLATE
     else
       raise SendEnvelopeError, 'There is an error on the child record, possibly incomplete details'
     end
@@ -101,9 +101,12 @@ class Childcare::SendDocusignEnvelope < ApplicationService
   end
 
   def childcare_no_misc_health?
-    return true if child&.childcare_medical_history&.health_misc.blank?
+    misc = child&.childcare_medical_history&.health_misc
+    misc.blank? || misc == ['None of the above']
+  end
 
-    child&.childcare_medical_history&.health_misc.exclude?('Other special need')
+  def childcare_camp_grade?
+    Child.childcare_camp_grade_levels.include?(child.grade_level)
   end
 
   def senior_grade?
@@ -111,9 +114,8 @@ class Childcare::SendDocusignEnvelope < ApplicationService
   end
 
   def senior_no_misc_health?
-    return true if child&.cru_student_medical_history&.cs_health_misc.blank?
-    
-    child&.childcare_medical_history&.health_misc == ['None of the above']
+    misc = child&.cru_student_medical_history&.cs_health_misc
+    misc.blank? || misc == ['None of the above']
   end
 
   def build_text_tabs
@@ -126,6 +128,10 @@ class Childcare::SendDocusignEnvelope < ApplicationService
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def build_general_fields
     [
+      {
+        label: 'SCOPersonID',
+        value: child.uuid
+      },
       {
         label: '\\*ChildFullName',
         value: child.full_name(skip_middle: true)
@@ -219,6 +225,10 @@ class Childcare::SendDocusignEnvelope < ApplicationService
         value: get_gender_formatted(child.gender)
       },
       {
+        label: 'ChildGender',
+        value:  get_gender_formatted(child.gender)
+      },
+      {
         label: 'Parent1Email',
         value: recipient.email
       }
@@ -233,7 +243,63 @@ class Childcare::SendDocusignEnvelope < ApplicationService
     mh = child.childcare_medical_history
     [
       {
-        label: 'Forms-CC-MH-Allergy',
+        label: 'Forms-CC-MH-Allergies-Eggs',
+        value: check_if_in_list(mh.cc_allergies, 'Eggs')
+      },
+      {
+        label: 'Forms-CC-MH-Allergies-Milk',
+        value: check_if_in_list(mh.cc_allergies, 'Milk')
+      },
+      {
+        label: 'Forms-CC-MH-Allergies-TreeNuts',
+        value: check_if_in_list(mh.cc_allergies, 'Tree nuts')
+      },
+      {
+        label: 'Forms-CC-MH-Allergies-Fish',
+        value: check_if_in_list(mh.cc_allergies, 'Fish/Shellfish')
+      },
+      {
+        label: 'Forms-CC-MH-Allergies-Peanuts',
+        value: check_if_in_list(mh.cc_allergies, 'Peanuts')
+      },
+      {
+        label: 'Forms-CC-MH-Allergies-Wheat',
+        value: check_if_in_list(mh.cc_allergies, 'Wheat')
+      },
+      {
+        label: 'Forms-CC-MH-Allergies-InsectSting',
+        value: check_if_in_list(mh.cc_allergies, 'Insect sting')
+      },
+      {
+        label: 'Forms-CC-MH-Allergies-Pollen',
+        value: check_if_in_list(mh.cc_allergies, 'Pollen')
+      },
+      {
+        label: 'Forms-CC-MH-Allergies-Meds',
+        value: check_if_in_list(mh.cc_allergies, 'Medications')
+      },
+      {
+        label: 'Forms-CC-MH-Allergies-Latex',
+        value: check_if_in_list(mh.cc_allergies, 'Latex')
+      },
+      {
+        label: 'Forms-CC-MH-Allergies-Soy',
+        value: check_if_in_list(mh.cc_allergies, 'Soy')
+      },
+      {
+        label: 'Forms-CC-MH-Allergies-Other',
+        value: check_if_in_list(mh.cc_allergies, 'Other')
+      },
+      {
+        label: 'Forms-CC-MH-Allergies-Nota',
+        value: check_if_in_list(mh.cc_allergies, 'None of the above')
+      },
+      {
+        label: 'Forms-CC-MH-Med-Allergies',
+        value: mh.cc_medi_allergy
+      },
+      {
+        label: 'Forms-CC-MH-Other-Allergies',
         value: mh.allergy
       },
       {
@@ -241,92 +307,100 @@ class Childcare::SendDocusignEnvelope < ApplicationService
         value: mh.food_intolerance
       },
       {
-        label: 'Forms-CC-MH-Chronic-Health-Asthma',
+        label: 'Forms-CC-MH-Chronic-Asthma',
         value: check_if_in_list(mh.chronic_health, 'Asthma')
       },
       {
-        label: 'Forms-CC-MH-Chronic-Health-Diabetes',
+        label: 'Forms-CC-MH-Chronic-Diabetes',
         value: check_if_in_list(mh.chronic_health, 'Diabetes')
       },
       {
-        label: 'Forms-CC-MH-Chronic-Health-Allergy',
+        label: 'Forms-CC-MH-Chronic-Epilepsy',
+        value: check_if_in_list(mh.chronic_health, 'Epilepsy')
+      },
+      {
+        label: 'Forms-CC-MH-Chronic-SevereAllergy',
         value: check_if_in_list(mh.chronic_health, 'Severe allergy')
       },
       {
-        label: 'Forms-CC-MH-Chronic-Health-Other',
+        label: 'Forms-CC-MH-Chronic-Other',
         value: check_if_in_list(mh.chronic_health, 'Other')
       },
       {
-        label: 'Forms-CC-MH-Chronic-Health-Addl',
+        label: 'Forms-CC-MH-Chronic-Nota',
+        value: check_if_in_list(mh.chronic_health, 'None of the above')
+      },
+      {
+        label: 'Forms-CC-MH-Chronic-OtherAdditional',
         value: mh.chronic_health_addl
       },
       {
-        label: 'Forms-CC-MH-Medications',
+        label: 'Forms-CC-MH-AllMeds',
         value: mh.medications
-      },
+      },      
       {
-        label: 'Forms-CC-MH-Immunizations',
+        label: 'Forms CC MH Immunizations',
         value: checkmark_if_yes(mh.immunizations&.join)
       },
       {
-        label: 'Forms-CC-MH-Health-Misc-Delay',
+        label: 'Forms CC MH non-immunized',
+        value: checkmark_if_yes(mh.non_immunizations&.join)
+      },
+      {
+        label: 'Forms-CC-MH-Certify-No',
+        value: checkmark_if_no(mh.cc_restriction_certified&.join)
+      },
+      {
+        label: 'Forms-CC-MH-Certify-Yes',
+        value: checkmark_if_yes(mh.cc_restriction_certified&.join)
+      },
+      {
+        label: 'Forms-CC-MH-Certify-Restrictions',
+        value: mh.restrictions
+      },
+      {
+        label: 'Forms-CC-MH-Health-Misc-DownSyndrome',
+        value: check_if_in_list(mh.health_misc, 'Down Syndrome')
+      },
+      {
+        label: 'Forms-CC-MH-Health-Misc-ADHD',
+        value: check_if_in_list(mh.health_misc, 'ADHD/ADD')
+      },
+      {
+        label: 'Forms-CC-MH-Health-Misc-Developmental-delay',
         value: check_if_in_list(mh.health_misc, 'Developmental delay')
       },
-      # {
-      #   label: 'Forms-CC-MH-Health-Misc-Delay-Sensory',
-      #   value: check_if_in_list(mh.health_misc, 'Sensory Processing Disorder')
-      # },
       {
         label: 'Forms-CC-MH-Health-Misc-Other-special-need',
         value: check_if_in_list(mh.health_misc, 'Other special need')
       },
       {
-        label: 'Forms-CC-MH-Health-Misc-Delay-Behavioral',
+        label: 'Forms-CC-MH-Health-Misc-Behavioral-challenges',
         value: check_if_in_list(mh.health_misc, 'Behavioral challenges')
       },
       {
-        label: 'Forms-CC-MH-Health-Misc-Delay-Autism',
+        label: 'Forms-CC-MH-Health-Misc-Autism',
         value: check_if_in_list(mh.health_misc, 'Disability')
       },
       {
-        label: 'Forms-CC-MH-Health-Misc-Delay-Assistance',
+        label: 'Forms-CC-MH-Health-Misc-Extra-assistance',
         value: check_if_in_list(mh.health_misc, 'Extra assistance')
       },
       {
-        label: 'Forms-CC-MH-Health-Misc-Delay-Equipment',
+        label: 'Forms-CC-MH-Health-Misc-Adaptive-equipment',
         value: check_if_in_list(mh.health_misc, 'Adaptive equipment')
       },
       {
-        label: 'Forms-CC-MH-Health-Misc-Delay-None',
+        label: 'Forms-CC-MH-Health-Misc-Nota',
         value: check_if_in_list(mh.health_misc, 'None of the above')
       },
       {
-        label: 'Forms-CC-MH-Restrictions',
-        value: mh.restrictions
+        label: 'Forms-CC-MH-Health-Misc-Other',
+        value: check_if_in_list(mh.health_misc, 'Other special need')
       },
       {
-        label: 'Forms-CC-Sunscreen-Self-Yes',
-        value: checkmark_if_yes(mh.sunscreen_self)
-      },
-      {
-        label: 'Forms-CC-Sunscreen-Self-No',
-        value: checkmark_if_no(mh.sunscreen_self)
-      },
-      {
-        label: 'Forms-CC-Sunscreen-Assisted-Yes',
-        value: checkmark_if_yes(mh.sunscreen_assisted)
-      },
-      {
-        label: 'Forms-CC-Sunscreen-Assisted-No',
-        value: checkmark_if_no(mh.sunscreen_assisted)
-      },
-      {
-        label: 'Forms-CC-Sunscreen-Provided-Yes',
-        value: checkmark_if_yes(mh.sunscreen_provided)
-      },
-      {
-        label: 'Forms-CC-Sunscreen-Provided-No',
-        value: checkmark_if_no(mh.sunscreen_provided)
+        label: 'Forms-CC-MH-Health-Misc-OtherSpecialNeeds',
+        value: mh.cc_other_special_needs
       }
     ]
   end
@@ -343,8 +417,8 @@ class Childcare::SendDocusignEnvelope < ApplicationService
         value: mh.vip_meds
       },
       {
-        label: 'Forms-CC-VIP-Dev',
-        value: mh.vip_dev
+        label: 'Forms-CC-VIP-DevAge',
+        value: mh.cc_vip_developmental_age
       },
       {
         label: 'Forms-CC-VIP-Strengths',
@@ -395,15 +469,15 @@ class Childcare::SendDocusignEnvelope < ApplicationService
         value: mh.vip_comm_directions
       },
       {
-        label: 'Forms-CC-VIP-Stress-Noisy',
+        label: 'Forms-CC-VIP-Stress-Noisy-spaces',
         value: check_if_in_list(mh.vip_stress, 'Noisy spaces')
       },
       {
-        label: 'Forms-CC-VIP-Stress-Crowded',
+        label: 'Forms-CC-VIP-Stress-Crowded-spaces',
         value: check_if_in_list(mh.vip_stress, 'Crowded spaces')
       },
       {
-        label: 'Forms-CC-VIP-Stress-Loud',
+        label: 'Forms-CC-VIP-Stress-Loud-noises',
         value: check_if_in_list(mh.vip_stress, 'Loud noises')
       },
       {
@@ -411,12 +485,20 @@ class Childcare::SendDocusignEnvelope < ApplicationService
         value: check_if_in_list(mh.vip_stress, 'Heights')
       },
       {
-        label: 'Forms-CC-VIP-Stress-Change',
+        label: 'Forms-CC-VIP-Stress-ChangingSchedule',
         value: check_if_in_list(mh.vip_stress, 'Changing schedule')
       },
       {
         label: 'Forms-CC-VIP-Stress-Other',
         value: check_if_in_list(mh.vip_stress, 'Other')
+      },
+      {
+        label: 'Forms-CC-VIP-Stress-Nota',
+        value: check_if_in_list(mh.vip_stress, 'None of the above')
+      },
+      {
+        label: 'Forms-CC-VIP-Sitting',
+        value: mh.cc_vip_sitting
       },
       {
         label: 'Forms-CC-VIP-Stress-Addl',
@@ -441,6 +523,10 @@ class Childcare::SendDocusignEnvelope < ApplicationService
       {
         label: 'Forms-CC-VIP-AddlInfo',
         value: mh.vip_addl_info
+      },
+      {
+        label: 'Forms-CC-MH-StaffAdministeredMeds',
+        value: mh.cc_vip_staff_administered_meds
       }
     ]
   end
@@ -573,6 +659,10 @@ class Childcare::SendDocusignEnvelope < ApplicationService
         value: check_if_in_list(smh.gtky_challenges, 'Other')
       },
       {
+        label: 'Forms-CS-GTKY-Challenges-Nota',
+        value: check_if_in_list(smh.gtky_challenges, 'None of the above')
+      },
+      {
         label: 'Forms-CS-GTKY-Addl-Challenges',
         value: smh.gtky_addl_challenges
       },
@@ -631,12 +721,56 @@ class Childcare::SendDocusignEnvelope < ApplicationService
     smh = child.cru_student_medical_history
     [
       {
-        label: 'Forms-CS-MH-Allergies-No',
-        value: checkmark_if_no(smh.gtky_allergies)
+        label: 'Forms-CS-MH-Allergies-Eggs',
+        value: check_if_in_list(smh.cs_allergies, 'Eggs')
       },
       {
-        label: 'Forms-CS-MH-Allergies-Yes',
-        value: checkmark_if_yes(smh.gtky_allergies)
+        label: 'Forms-CS-MH-Allergies-Milk',
+        value: check_if_in_list(smh.cs_allergies, 'Milk')
+      },
+      {
+        label: 'Forms-CS-MH-Allergies-TreeNuts',
+        value: check_if_in_list(smh.cs_allergies, 'Tree nuts')
+      },
+      {
+        label: 'Forms-CS-MH-Allergies-Fish',
+        value: check_if_in_list(smh.cs_allergies, 'Fish/Shellfish')
+      },
+      {
+        label: 'Forms-CS-MH-Allergies-Peanuts',
+        value: check_if_in_list(smh.cs_allergies, 'Peanuts')
+      },
+      {
+        label: 'Forms-CS-MH-Allergies-Wheat',
+        value: check_if_in_list(smh.cs_allergies, 'Wheat')
+      },
+      {
+        label: 'Forms-CS-MH-Allergies-InsectSting',
+        value: check_if_in_list(smh.cs_allergies, 'Insect sting')
+      },
+      {
+        label: 'Forms-CS-MH-Allergies-Pollen',
+        value: check_if_in_list(smh.cs_allergies, 'Pollen')
+      },
+      {
+        label: 'Forms-CS-MH-Allergies-Meds',
+        value: check_if_in_list(smh.cs_allergies, 'Medications')
+      },
+      {
+        label: 'Forms-CS-MH-Allergies-Latex',
+        value: check_if_in_list(smh.cs_allergies, 'Latex')
+      },
+      {
+        label: 'Forms-CS-MH-Allergies-Soy',
+        value: check_if_in_list(smh.cs_allergies, 'Soy')
+      },
+      {
+        label: 'Forms-CS-MH-Allergies-Other',
+        value: check_if_in_list(smh.cs_allergies, 'Other')
+      },
+      {
+        label: 'Forms-CS-MH-Allergies-Nota',
+        value: check_if_in_list(smh.cs_allergies, 'None of the above')
       },
       {
         label: 'Forms-CS-MH-Med-Allergies',
@@ -659,32 +793,48 @@ class Childcare::SendDocusignEnvelope < ApplicationService
         value: checkmark_if_yes(smh.health_concerns)
       },
       {
-        label: 'Forms-CS-MH-Asthma',
-        value: smh.asthma
+        label: 'Forms-CS-MH-Chronic-Asthma',
+        value: check_if_in_list(smh.cs_chronic_health, 'Asthma')
       },
       {
-        label: 'Forms-CS-MH-Migraines',
-        value: smh.migraines
+        label: 'Forms-CS-MH-Chronic-Migraine',
+        value: check_if_in_list(smh.cs_chronic_health, 'Migraine')
       },
       {
-        label: 'Forms-CS-MH-Severe-allergy',
-        value: smh.severe_allergy
+        label: 'Forms-CS-MH-Chronic-SevereAllergy',
+        value: check_if_in_list(smh.cs_chronic_health, 'Severe allergy')
       },
       {
-        label: 'Forms-CS-MH-Anorexia',
-        value: smh.anorexia
+        label: 'Forms-CS-MH-Chronic-Anorexia',
+        value: check_if_in_list(smh.cs_chronic_health, 'Anorexia')
       },
       {
-        label: 'Forms-CS-MH-Diabetes',
-        value: smh.diabetes
+        label: 'Forms-CS-MH-Chronic-Diabetes',
+        value: check_if_in_list(smh.cs_chronic_health, 'Diabetes')
+      },
+      {
+        label: 'Forms-CS-MH-Chronic-Epilepsy',
+        value: check_if_in_list(smh.cs_chronic_health, 'Epilepsy')  
+      },
+      {
+        label: 'Forms-CS-MH-Chronic-Other',
+        value: check_if_in_list(smh.cs_chronic_health, 'Other')
+      },
+      {
+        label: 'Forms-CS-MH-Chronic-Nota',
+        value: check_if_in_list(smh.cs_chronic_health, 'None of the above')  
       },
       {
         label: 'Forms-CS-MH-Altitude',
         value: smh.altitude
       },
       {
-        label: 'Forms-CS-MH-Concerns-Misc',
+        label: 'Forms-CS-MH-Chronic-OtherAdditional',
         value: smh.concerns_misc
+      },
+      {
+        label: 'Forms-CS-MH-AllMeds',
+        value: smh.cs_medications
       },
       {
         label: 'Forms-CS-MH-Health-Misc-Developmental-delay',
@@ -695,11 +845,11 @@ class Childcare::SendDocusignEnvelope < ApplicationService
       #   value: check_if_in_list(smh.cs_health_misc, 'Sensory issues')
       # },
       {
-        label: 'Forms-CS-MH-Health-Misc-Other-special-need',
-        value: check_if_in_list(smh.cs_health_misc, 'Other special need')### added JaPache
+        label: 'Forms-CS-MH-Health-Misc-Other',
+        value: check_if_in_list(smh.cs_health_misc, 'Other')### added JaPache
       },
       {
-        label: 'Forms-CS-MH-Health-Misc-Behavioral-issues',
+        label: 'Forms-CS-MH-Health-Misc-Behavioral-challenges',
         value: check_if_in_list(smh.cs_health_misc, 'Behavioral challenges')
       },
       {
@@ -715,8 +865,36 @@ class Childcare::SendDocusignEnvelope < ApplicationService
         value: check_if_in_list(smh.cs_health_misc, 'Adaptive equipment')
       },
       {
-        label: 'Forms-CS-MH-Health-Misc-None-of-the-above',
+        label: 'Forms-CS-MH-Health-Misc-ADHD',
+        value: check_if_in_list(smh.cs_health_misc, 'ADHD/ADD')
+      },
+      {
+        label: 'Forms-CS-MH-Health-Misc-DownSyndrome',
+        value: check_if_in_list(smh.cs_health_misc, 'Down Syndrome')
+      },
+      {
+        label: 'Forms-CS-MH-Health-Misc-Autism',
+        value: check_if_in_list(smh.cs_health_misc, 'Autism')
+      },
+      {
+        label: 'Forms-CS-MH-Health-Misc-Nota',
         value: check_if_in_list(smh.cs_health_misc, 'None of the above')
+      },
+      {
+        label: 'Forms-CS-MH-Health-Misc-OtherSpecialNeeds',
+        value: smh.cs_other_special_needs
+      },
+      {
+        label: 'Forms-CS-MH-Certify-No',
+        value: checkmark_if_no(smh.cs_restriction_certified&.join)
+      },
+      {
+        label: 'Forms-CS-MH-Certify-Yes',
+        value: checkmark_if_yes(smh.cs_restriction_certified&.join)
+      },
+      {
+        label: 'Forms-CS-MH-Certify-Restrictions',
+        value: smh.cs_restrictions
       }
     ]
   end
@@ -733,8 +911,8 @@ class Childcare::SendDocusignEnvelope < ApplicationService
         value: smh.cs_vip_meds
       },
       {
-        label: 'Forms-CS-VIP-Dev',
-        value: smh.cs_vip_dev
+        label: 'Forms-CS-VIP-DevAge',
+        value: smh.cs_vip_developmental_age
       },
       {
         label: 'Forms-CS-VIP-Strengths',
@@ -793,8 +971,24 @@ class Childcare::SendDocusignEnvelope < ApplicationService
         value: check_if_in_list(smh.cs_vip_stress, 'Loud noises')
       },
       {
+        label: 'Forms-CS-VIP-Stress-Heights',
+        value: check_if_in_list(smh.cs_vip_stress, 'Heights')
+      },
+      {
+        label: 'Forms-CS-VIP-Stress-ChangingSchedule',
+        value: check_if_in_list(smh.cs_vip_stress, 'Changing schedule')
+      },
+      {
         label: 'Forms-CS-VIP-Stress-Other',
         value: check_if_in_list(smh.cs_vip_stress, 'Other')
+      },
+      {
+        label: 'Forms-CS-VIP-Stress-Nota',
+        value: check_if_in_list(smh.cs_vip_stress, 'None of the above')
+      },
+      {
+        label: 'Forms-CS-VIP-Sitting',
+        value: smh.cs_vip_sitting
       },
       {
         label: 'Forms-CS-VIP-Stress-Addl',
@@ -823,7 +1017,12 @@ class Childcare::SendDocusignEnvelope < ApplicationService
       {
         label: 'Forms-CS-VIP-AddlInfo',
         value: smh.cs_vip_addl_info
+      },
+      {
+        label: 'Forms-CS-MH-StaffAdministeredMeds',
+        value: smh.cs_vip_staff_administered_meds
       }
+      
     ]
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/app/services/childcare/send_docusign_envelope.rb
+++ b/app/services/childcare/send_docusign_envelope.rb
@@ -830,7 +830,7 @@ class Childcare::SendDocusignEnvelope < ApplicationService
       },
       {
         label: 'Forms-CS-MH-Chronic-OtherAdditional',
-        value: smh.concerns_misc
+        value: smh.cs_chronic_health_addl
       },
       {
         label: 'Forms-CS-MH-AllMeds',

--- a/app/services/childcare/send_docusign_envelope.rb
+++ b/app/services/childcare/send_docusign_envelope.rb
@@ -84,11 +84,11 @@ class Childcare::SendDocusignEnvelope < ApplicationService
 
   # rubocop:disable Metrics/PerceivedComplexity
   def determine_docusign_template
-    if childcare_grade?
+    if Child.kids_care_grades.include?(child.grade_level)
       childcare_no_misc_health? ? KIDS_CARE_NO_VIP_TEMPLATE : KIDS_CARE_WITH_VIP_TEMPLATE
-    elsif childcare_camp_grade?
+    elsif Child.kids_camp_grades.include?(child.grade_level)
       childcare_no_misc_health? ? KIDS_CAMP_NO_VIP_TEMPLATE : KIDS_CAMP_WITH_VIP_TEMPLATE
-    elsif senior_grade?
+    elsif Child.senior_grade_levels.include?(child.grade_level)
       senior_no_misc_health? ? CRUSTU_NO_VIP_TEMPLATE : CRUSTU_WITH_VIP_TEMPLATE
     else
       raise SendEnvelopeError, 'There is an error on the child record, possibly incomplete details'
@@ -96,21 +96,9 @@ class Childcare::SendDocusignEnvelope < ApplicationService
   end
   # rubocop:enable Metrics/PerceivedComplexity
 
-  def childcare_grade?
-    Child.childcare_grade_levels.include?(child.grade_level)
-  end
-
   def childcare_no_misc_health?
     misc = child&.childcare_medical_history&.health_misc
     misc.blank? || misc == ['None of the above']
-  end
-
-  def childcare_camp_grade?
-    Child.childcare_camp_grade_levels.include?(child.grade_level)
-  end
-
-  def senior_grade?
-    Child.senior_grade_levels.include?(child.grade_level)
   end
 
   def senior_no_misc_health?

--- a/app/services/childcare/send_docusign_envelope.rb
+++ b/app/services/childcare/send_docusign_envelope.rb
@@ -987,7 +987,7 @@ class Childcare::SendDocusignEnvelope < ApplicationService
         value: smh.cs_vip_addl_info
       },
       {
-        label: 'Forms-CS-MH-StaffAdministeredMeds',
+        label: '\\*Forms-CS-MH-StaffAdministeredMeds',
         value: smh.cs_vip_staff_administered_meds
       }
       

--- a/app/services/childcare/send_docusign_envelope.rb
+++ b/app/services/childcare/send_docusign_envelope.rb
@@ -801,7 +801,7 @@ class Childcare::SendDocusignEnvelope < ApplicationService
         value: smh.cs_chronic_health_addl
       },
       {
-        label: 'Forms-CS-MH-AllMeds',
+        label: '\\*Forms-CS-MH-AllMeds',
         value: smh.cs_medications
       },
       {

--- a/app/services/childcare/send_docusign_envelope.rb
+++ b/app/services/childcare/send_docusign_envelope.rb
@@ -315,11 +315,11 @@ class Childcare::SendDocusignEnvelope < ApplicationService
         value: checkmark_if_yes(mh.non_immunizations&.join)
       },
       {
-        label: 'Forms-CC-MH-Certify-No',        
+        label: 'Forms-CC-MH-Certify-Yes',        
         value: checkmark_if_value(mh.cc_restriction_certified, 'CruKids_certify_NOres')
       },
       {
-        label: 'Forms-CC-MH-Certify-Yes',
+        label: 'Forms-CC-MH-Certify-No',
         value: checkmark_if_value(mh.cc_restriction_certified, 'CruKids_certify_WITHres')
       },
       {
@@ -853,11 +853,11 @@ class Childcare::SendDocusignEnvelope < ApplicationService
         value: smh.cs_other_special_needs
       },
       {
-        label: 'Forms-CS-MH-Certify-No',
+        label: 'Forms-CS-MH-Certify-Yes',
         value: checkmark_if_value(smh.cs_restriction_certified, 'CruKids_certify_NOres')
       },
       {
-        label: 'Forms-CS-MH-Certify-Yes',
+        label: 'Forms-CS-MH-Certify-No',
         value: checkmark_if_value(smh.cs_restriction_certified, 'CruKids_certify_WITHres')
       },
       {

--- a/app/services/import/attributes/update_child.rb
+++ b/app/services/import/attributes/update_child.rb
@@ -17,9 +17,11 @@ module Import
         person.assign_attributes(
           needs_bed: @import.needs_bed,
           grade_level: @import.grade_level,
-          # childcare_deposit: @import.childcare_deposit,
           childcare_comment: @import.childcare_comment,
-          county: @import.county
+          county: @import.county,
+          childcare_cancellation_fee: @import.childcare_cancellation_fee,
+          childcare_late_fee: @import.childcare_late_fee,
+          tracking_id: @import.tracking_id
         )
 
         person.childcare_weeks = childcare_weeks(@import.childcare_weeks)

--- a/app/services/import/attributes/update_child.rb
+++ b/app/services/import/attributes/update_child.rb
@@ -18,7 +18,8 @@ module Import
           needs_bed: @import.needs_bed,
           grade_level: @import.grade_level,
           # childcare_deposit: @import.childcare_deposit,
-          childcare_comment: @import.childcare_comment
+          childcare_comment: @import.childcare_comment,
+          county: @import.county
         )
 
         person.childcare_weeks = childcare_weeks(@import.childcare_weeks)

--- a/app/services/import/update_medical_history_from_import.rb
+++ b/app/services/import/update_medical_history_from_import.rb
@@ -41,7 +41,8 @@ module Import
         cc_restriction_certified: @import.cc_restriction_certified,
         cc_vip_sitting: @import.cc_vip_sitting,
         cc_vip_developmental_age: @import.cc_vip_developmental_age,
-        cc_other_special_needs: @import.cc_other_special_needs
+        cc_other_special_needs: @import.cc_other_special_needs,
+        cc_vip_staff_administered_meds: @import.cc_vip_staff_administered_meds
       )
       person.childcare_medical_history = childcare_medical_history
     end

--- a/app/services/import/update_medical_history_from_import.rb
+++ b/app/services/import/update_medical_history_from_import.rb
@@ -40,7 +40,7 @@ module Import
         vip_addl_info: @import.vip_addl_info,
         cc_restriction_certified: @import.cc_restriction_certified,
         cc_vip_sitting: @import.cc_vip_sitting,
-        cc_vip_developmental_age: @import.cc_vip_developmental_age
+        cc_vip_developmental_age: @import.cc_vip_developmental_age      
       )
       person.childcare_medical_history = childcare_medical_history
     end
@@ -93,7 +93,9 @@ module Import
         cs_vip_staff_administered_meds: @import.cs_vip_staff_administered_meds,
         cs_chronic_health: @import.cs_chronic_health,
         cs_medications: @import.cs_medications,
-        cs_vip_developmental_age: @import.cs_vip_developmental_age
+        cs_vip_developmental_age: @import.cs_vip_developmental_age,
+        cs_chronic_health_addl: @import.cs_chronic_health_addl,
+        cs_restrictions: @import.cs_restrictions
       )
       person.cru_student_medical_history = student_medical_history
     end

--- a/app/services/import/update_medical_history_from_import.rb
+++ b/app/services/import/update_medical_history_from_import.rb
@@ -40,7 +40,8 @@ module Import
         vip_addl_info: @import.vip_addl_info,
         cc_restriction_certified: @import.cc_restriction_certified,
         cc_vip_sitting: @import.cc_vip_sitting,
-        cc_vip_developmental_age: @import.cc_vip_developmental_age      
+        cc_vip_developmental_age: @import.cc_vip_developmental_age,
+        cc_other_special_needs: @import.cc_other_special_needs
       )
       person.childcare_medical_history = childcare_medical_history
     end

--- a/app/views/children/_show.html.arb
+++ b/app/views/children/_show.html.arb
@@ -45,23 +45,26 @@ context.instance_exec do
       if child.childcare_medical_history&.any_attribute_present? && child.age_group == :childcare
         panel 'Care/Camp Medical History', class: 'medical_history' do
           attributes_table_for child.childcare_medical_history do
+            row :cc_allergies
             row :allergy
+            row :cc_medi_allergy
             row :food_intolerance
             row :chronic_health
             row :chronic_health_addl
             row :medications
             row :immunizations
+            row :non_immunizations
             row :health_misc
+            row :cc_other_special_needs
             row :restrictions
-            row :sunscreen_self
-            row :sunscreen_assisted
-            row :sunscreen_provided
           end
         end
 
         panel 'Care/Camp VIP Information', class: 'medical_history' do
           attributes_table_for child.childcare_medical_history do
+            row :cc_vip_developmental_age
             row :vip_meds
+            row :cc_vip_staff_administered_meds
             row :vip_dev
             row :vip_strengths
             row :vip_challenges
@@ -74,6 +77,7 @@ context.instance_exec do
             row :vip_comm_directions
             row :vip_stress
             row :vip_stress_addl
+            row :cc_vip_sitting
             row :vip_stress_behavior
             row :vip_calm
             row :vip_hobby
@@ -135,20 +139,21 @@ context.instance_exec do
             row :food_allergies
             row :other_allergies
             row :health_concerns
-            row :asthma
-            row :migraines
-            row :severe_allergy
-            row :anorexia
-            row :diabetes
-            row :altitude
-            row :concerns_misc
+            row :cs_allergies
+            row :cs_other_special_needs  
+            row :cs_chronic_health_addl
             row :cs_health_misc
+            row :cs_medications
+            row :cs_restriction_certified
+            row :cs_restrictions
+            row :crustu_forms_acknowledged
           end
         end
 
         panel 'CruStu VIP Information', class: 'medical_history' do
           attributes_table_for child.cru_student_medical_history do
-            row :cs_vip_meds
+            row :cs_vip_developmental_age
+            row :cs_vip_staff_administered_meds
             row :cs_vip_dev
             row :cs_vip_strengths
             row :cs_vip_challenges

--- a/app/views/children/_show.html.arb
+++ b/app/views/children/_show.html.arb
@@ -67,6 +67,7 @@ context.instance_exec do
                 status_tag(value, class: value == 'Yes' ? :ok : :warning)
               end
             end
+            row :restrictions
           end
         end
 

--- a/app/views/children/_show.html.arb
+++ b/app/views/children/_show.html.arb
@@ -87,6 +87,7 @@ context.instance_exec do
     column do
       panel 'Forms Approval', class: 'forms_approved' do
         attributes_table_for child do
+          row :uuid 
           row :forms_approved
           row :forms_approved_by
         end

--- a/app/views/children/_show.html.arb
+++ b/app/views/children/_show.html.arb
@@ -35,10 +35,12 @@ context.instance_exec do
           row(:childcare) do |c|
             link_to chilcare_spaces_label(c.childcare), c.childcare if c.childcare
           end
-          row :childcare_deposit
+          row :childcare_late_fee
+          row :childcare_cancellation_fee
           row(:childcare_weeks) { |c| childcare_weeks_list(c) }
           row(:hot_lunch_weeks) { |c| hot_lunch_weeks_list(c) }
           row :childcare_comment
+          row :county
         end
       end
 
@@ -63,8 +65,7 @@ context.instance_exec do
 
         panel 'Care/Camp VIP Information', class: 'medical_history' do
           attributes_table_for child.childcare_medical_history do
-            row :cc_vip_developmental_age
-            row :vip_meds
+            row :cc_vip_developmental_age            
             row :vip_dev
             row :vip_strengths
             row :vip_challenges

--- a/app/views/children/_show.html.arb
+++ b/app/views/children/_show.html.arb
@@ -52,6 +52,7 @@ context.instance_exec do
             row :chronic_health
             row :chronic_health_addl
             row :medications
+            row :cc_vip_staff_administered_meds
             row :immunizations
             row :non_immunizations
             row :health_misc
@@ -64,7 +65,6 @@ context.instance_exec do
           attributes_table_for child.childcare_medical_history do
             row :cc_vip_developmental_age
             row :vip_meds
-            row :cc_vip_staff_administered_meds
             row :vip_dev
             row :vip_strengths
             row :vip_challenges
@@ -140,10 +140,12 @@ context.instance_exec do
             row :other_allergies
             row :health_concerns
             row :cs_allergies
-            row :cs_other_special_needs  
+            row :cs_other_special_needs
+            row :cs_chronic_health
             row :cs_chronic_health_addl
             row :cs_health_misc
             row :cs_medications
+            row :cs_vip_staff_administered_meds
             row :cs_restriction_certified
             row :cs_restrictions
             row :crustu_forms_acknowledged
@@ -153,7 +155,6 @@ context.instance_exec do
         panel 'CruStu VIP Information', class: 'medical_history' do
           attributes_table_for child.cru_student_medical_history do
             row :cs_vip_developmental_age
-            row :cs_vip_staff_administered_meds
             row :cs_vip_dev
             row :cs_vip_strengths
             row :cs_vip_challenges

--- a/app/views/children/_show.html.arb
+++ b/app/views/children/_show.html.arb
@@ -59,7 +59,14 @@ context.instance_exec do
             row :non_immunizations
             row :health_misc
             row :cc_other_special_needs
-            row :restrictions
+            cc_values = Array(resource.childcare_medical_history&.cc_restriction_certified)
+            keys = %w[CruKids_certify_WITHres CruKids_certify_NOres]
+            keys.each do |key|
+              row I18n.t("activerecord.attributes.childcare_medical_history.cc_restriction_certified_values.#{key}") do
+                value = cc_values.include?(key) ? I18n.t('yes', default: 'Yes') : I18n.t('no', default: 'No')
+                status_tag(value, class: value == 'Yes' ? :ok : :warning)
+              end
+            end
           end
         end
 
@@ -92,7 +99,10 @@ context.instance_exec do
     column do
       panel 'Forms Approval', class: 'forms_approved' do
         attributes_table_for child do
-          row :uuid 
+          row :uuid do |child|
+            value = child.uuid.to_s
+            content_tag(:span, value)
+          end
           row :forms_approved
           row :forms_approved_by
         end
@@ -147,7 +157,14 @@ context.instance_exec do
             row :cs_health_misc
             row :cs_medications
             row :cs_vip_staff_administered_meds
-            row :cs_restriction_certified
+            cs_values = Array(resource.cru_student_medical_history&.cs_restriction_certified)
+            keys = %w[CruKids_certify_WITHres CruKids_certify_NOres]
+            keys.each do |key|
+              row I18n.t("activerecord.attributes.cru_student_medical_history.cs_restriction_certified_values.#{key}") do
+                value = cs_values.include?(key) ? I18n.t('yes', default: 'Yes') : I18n.t('no', default: 'No')
+                status_tag(value, class: value == 'Yes' ? :ok : :warning)
+              end
+            end
             row :cs_restrictions
             row :crustu_forms_acknowledged
           end

--- a/app/views/children/form/_childcare.html.arb
+++ b/app/views/children/form/_childcare.html.arb
@@ -1,6 +1,7 @@
 form.instance_exec do
   inputs 'Cru Kids' do
-    input :childcare_deposit, wrapper_html: { style: !policy.edit_deposit? ? 'display:none' : '' }
+    input :childcare_late_fee
+    input :childcare_cancellation_fee
     input :childcare_weeks, label: 'Weeks of ChildCare', multiple: true,
       hint: 'Please add all weeks needed',
       collection: childcare_weeks_select
@@ -12,5 +13,6 @@ form.instance_exec do
       hint: 'Please add all weeks needed',
       collection: childcare_weeks_select
     input :childcare_comment, input_html: { rows: 4 }
+    input :county
   end
 end

--- a/app/views/children/form/_childcare_medical_history.arb
+++ b/app/views/children/form/_childcare_medical_history.arb
@@ -11,10 +11,16 @@ form.instance_exec do
       s.input :chronic_health, as: :check_boxes, collection: ChildcareMedicalHistory.multi_selection_collections[:chronic_health]
       s.input :chronic_health_addl, input_html: { rows: 5 }
       s.input :medications, input_html: { rows: 5 }
+      s.input :cc_vip_staff_administered_meds, input_html: { rows: 5 }
       s.input :immunizations, as: :check_boxes, collection: ChildcareMedicalHistory.multi_selection_collections[:immunizations]
       s.input :non_immunizations, as: :check_boxes, collection: ChildcareMedicalHistory.multi_selection_collections[:immunizations] 
       s.input :health_misc, as: :check_boxes, collection: ChildcareMedicalHistory.multi_selection_collections[:health_misc]
       s.input :cc_other_special_needs, input_html: { rows: 5 }
+      s.input :cc_restriction_certified, as: :radio,
+                              collection: {
+                                'Certified Participation WITH Restrictions' => 'CruKids_certify_WITHres',
+                                'Certified Participation NO Restrictions' => 'CruKids_certify_NOres'
+                              }
       s.input :restrictions, input_html: { rows: 5 }      
     end
   end

--- a/app/views/children/form/_childcare_medical_history.arb
+++ b/app/views/children/form/_childcare_medical_history.arb
@@ -4,19 +4,18 @@ form.instance_exec do
     collection = [:childcare_medical_history, object.childcare_medical_history]
     has_many :childcare_medical_history, heading: nil, new_record: 'Add New Care/Camp Medical History',
              class: 'has_one', collection: collection do |s|
+      s.input :cc_allergies, as: :check_boxes, collection: ChildcareMedicalHistory.multi_selection_collections[:cc_allergies]
+      s.input :cc_medi_allergy, input_html: { rows: 5 }
       s.input :allergy, input_html: { rows: 5 }
       s.input :food_intolerance, input_html: { rows: 5 }
       s.input :chronic_health, as: :check_boxes, collection: ChildcareMedicalHistory.multi_selection_collections[:chronic_health]
       s.input :chronic_health_addl, input_html: { rows: 5 }
       s.input :medications, input_html: { rows: 5 }
       s.input :immunizations, as: :check_boxes, collection: ChildcareMedicalHistory.multi_selection_collections[:immunizations]
+      s.input :non_immunizations, as: :check_boxes, collection: ChildcareMedicalHistory.multi_selection_collections[:immunizations] 
       s.input :health_misc, as: :check_boxes, collection: ChildcareMedicalHistory.multi_selection_collections[:health_misc]
-      s.input :restrictions, input_html: { rows: 5 }
-      s.input :sunscreen_self, as: :radio, collection: ChildcareMedicalHistory.single_selection_collections[:sunscreen_self]
-      s.input :sunscreen_assisted, as: :radio,
-                                   collection: ChildcareMedicalHistory.single_selection_collections[:sunscreen_assisted]
-      s.input :sunscreen_provided, as: :radio,
-                                   collection: ChildcareMedicalHistory.single_selection_collections[:sunscreen_provided]
+      s.input :cc_other_special_needs, input_html: { rows: 5 }
+      s.input :restrictions, input_html: { rows: 5 }      
     end
   end
 end

--- a/app/views/children/form/_childcare_medical_history_vip.arb
+++ b/app/views/children/form/_childcare_medical_history_vip.arb
@@ -4,7 +4,9 @@ form.instance_exec do
     collection = [:childcare_medical_history, object.childcare_medical_history]
     has_many :childcare_medical_history, heading: nil, new_record: 'Add New Care/Camp VIP Information',
              class: 'has_one', collection: collection do |s|
+      s.input :cc_vip_developmental_age, input_html: { rows: 5 }
       s.input :vip_meds, input_html: { rows: 5 }
+      s.input :cc_vip_staff_administered_meds, input_html: { rows: 5 }
       s.input :vip_dev, input_html: { rows: 5 }
       s.input :vip_strengths, input_html: { rows: 5 }
       s.input :vip_challenges, input_html: { rows: 5 }
@@ -17,6 +19,7 @@ form.instance_exec do
       s.input :vip_comm_directions, input_html: { rows: 5 }
       s.input :vip_stress, as: :check_boxes, collection: ChildcareMedicalHistory.multi_selection_collections[:vip_stress]
       s.input :vip_stress_addl, input_html: { rows: 5 }
+      s.input :cc_vip_sitting, input_html: { rows: 5 }
       s.input :vip_stress_behavior, input_html: { rows: 5 }
       s.input :vip_calm, input_html: { rows: 5 }
       s.input :vip_hobby, input_html: { rows: 5 }

--- a/app/views/children/form/_childcare_medical_history_vip.arb
+++ b/app/views/children/form/_childcare_medical_history_vip.arb
@@ -4,9 +4,7 @@ form.instance_exec do
     collection = [:childcare_medical_history, object.childcare_medical_history]
     has_many :childcare_medical_history, heading: nil, new_record: 'Add New Care/Camp VIP Information',
              class: 'has_one', collection: collection do |s|
-      s.input :cc_vip_developmental_age, input_html: { rows: 5 }
-      s.input :vip_meds, input_html: { rows: 5 }
-      s.input :cc_vip_staff_administered_meds, input_html: { rows: 5 }
+      s.input :cc_vip_developmental_age, input_html: { rows: 5 }      
       s.input :vip_dev, input_html: { rows: 5 }
       s.input :vip_strengths, input_html: { rows: 5 }
       s.input :vip_challenges, input_html: { rows: 5 }

--- a/app/views/children/form/_cru_student_medical_history.arb
+++ b/app/views/children/form/_cru_student_medical_history.arb
@@ -8,13 +8,10 @@ form.instance_exec do
       s.input :med_allergies
       s.input :food_allergies
       s.input :other_allergies
+      s.input :cs_chronic_health, as: :check_boxes, 
+                                  collection: CruStudentMedicalHistory.multi_selection_collections[:cs_chronic_health]
       s.input :health_concerns, as: :radio, collection: CruStudentMedicalHistory.single_selection_collections[:health_concerns]
-      s.input :asthma
-      s.input :migraines
-      s.input :severe_allergy
-      s.input :anorexia
-      s.input :diabetes
-      s.input :altitude
+      s.input :cs_allergies, as: :check_boxes, collection: CruStudentMedicalHistory.multi_selection_collections[:cs_allergies]
       s.input :concerns_misc
       s.input :cs_health_misc, as: :check_boxes,
                                collection: CruStudentMedicalHistory.multi_selection_collections[:cs_health_misc]

--- a/app/views/children/form/_cru_student_medical_history.arb
+++ b/app/views/children/form/_cru_student_medical_history.arb
@@ -12,9 +12,19 @@ form.instance_exec do
                                   collection: CruStudentMedicalHistory.multi_selection_collections[:cs_chronic_health]
       s.input :health_concerns, as: :radio, collection: CruStudentMedicalHistory.single_selection_collections[:health_concerns]
       s.input :cs_allergies, as: :check_boxes, collection: CruStudentMedicalHistory.multi_selection_collections[:cs_allergies]
-      s.input :concerns_misc
+      s.input :cs_chronic_health_addl, input_html: { rows: 5 }
       s.input :cs_health_misc, as: :check_boxes,
                                collection: CruStudentMedicalHistory.multi_selection_collections[:cs_health_misc]
+      s.input :cs_other_special_needs, input_html: { rows: 5 }      
+      s.input :crustu_forms_acknowledged, as: :radio,
+                               collection: CruStudentMedicalHistory.single_selection_collections[:crustu_forms_acknowledged]
+      s.input :cs_medications
+      s.input :cs_restriction_certified, as: :check_boxes,
+                                   collection: {
+                                     'I certify with reservations' => 'CruKids_certify_WITHres',
+                                     'I certify without reservations' => 'CruKids_certify_NOres'
+                                   }
+      s.input :cs_restrictions, input_html: { rows: 5 }
     end
   end
 end

--- a/app/views/children/form/_cru_student_medical_history.arb
+++ b/app/views/children/form/_cru_student_medical_history.arb
@@ -19,10 +19,10 @@ form.instance_exec do
       s.input :crustu_forms_acknowledged, as: :radio,
                                collection: CruStudentMedicalHistory.single_selection_collections[:crustu_forms_acknowledged]
       s.input :cs_medications
-      s.input :cs_restriction_certified, as: :check_boxes,
+      s.input :cs_restriction_certified, as: :radio,
                                    collection: {
-                                     'I certify with reservations' => 'CruKids_certify_WITHres',
-                                     'I certify without reservations' => 'CruKids_certify_NOres'
+                                     'Certified Participation WITH Restrictions' => 'CruKids_certify_WITHres',
+                                     'Certified Participation NO Restrictions' => 'CruKids_certify_NOres'
                                    }
       s.input :cs_restrictions, input_html: { rows: 5 }
     end

--- a/app/views/children/form/_cru_student_medical_history_vip.arb
+++ b/app/views/children/form/_cru_student_medical_history_vip.arb
@@ -3,8 +3,9 @@ form.instance_exec do
   panel 'CruStu VIP Information', class: 'cru_student_medical_history' do
     collection = [:cru_student_medical_history, object.cru_student_medical_history]
     has_many :cru_student_medical_history, heading: nil, new_record: 'Add New CruStu VIP Information',
-             class: 'has_one', collection: collection do |s|
-      s.input :cs_vip_meds, input_html: { rows: 5 }
+             class: 'has_one', collection: collection do |s|   
+      s.input :cs_vip_developmental_age, input_html: { rows: 5 }
+      s.input :cs_vip_staff_administered_meds, input_html: { rows: 5 }
       s.input :cs_vip_dev, input_html: { rows: 5 }
       s.input :cs_vip_strengths, input_html: { rows: 5 }
       s.input :cs_vip_challenges, input_html: { rows: 5 }

--- a/app/views/family_mailer/forms_approved.html.erb
+++ b/app/views/family_mailer/forms_approved.html.erb
@@ -20,5 +20,5 @@ If you have questions, please email <%= mail_to('Cru25.Info@cru.org') %>.
 
 <p>
   Thanks, <br>
-  Team22
+  Team25
 </p>

--- a/app/views/family_mailer/forms_approved.html.erb
+++ b/app/views/family_mailer/forms_approved.html.erb
@@ -7,15 +7,15 @@
 </p>
 
 <p>
-There is nothing more for you to do related to CruKids before your arrival for Cru22 except to look for a PreCheck email two weeks before your arrival.
+There is nothing more for you to do related to CruKids before your arrival for Cru25 except to look for a PreCheck email two weeks before your arrival.
 </p>
 
 <p>
-At that time, you will be able to view and confirm your conference details before your arrival, including your CruKids participation, to qualify for PreCheck at Cru22.
+At that time, you will be able to view and confirm your conference details before your arrival, including your CruKids participation, to qualify for PreCheck at Cru25.
 </p>
 
 <p>
-If you have questions, please email <%= mail_to('Cru22.Info@cru.org') %>.
+If you have questions, please email <%= mail_to('Cru25.Info@cru.org') %>.
 </p>
 
 <p>

--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,7 @@ docker buildx build $DOCKER_ARGS  \
     --build-arg SESSION_REDIS_HOST=$REDIS_IP \
     --build-arg STORAGE_REDIS_HOST=$REDIS_IP \
     --build-arg SECRET_KEY_BASE=$SECRET_KEY_BASE \
+    --build-arg EXTERNAL_API_KEY=$EXTERNAL_API_KEY \
     .
 rc=$?
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,7 +8,8 @@ Rails.application.configure do
 
   # Do not eager load code on boot.
   config.eager_load = false
-
+  config.hosts << /script\.google\.com/
+  config.hosts << /googleusercontent\.com/
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,8 +8,6 @@ Rails.application.configure do
 
   # Do not eager load code on boot.
   config.eager_load = false
-  config.hosts << /script\.google\.com/
-  config.hosts << /googleusercontent\.com/
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,11 +45,11 @@ Rails.application.configure do
   # if ENV["AWS_EXECUTION_ENV"].present?
   #   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
-    config.ssl_options = {
-      redirect: {
-        exclude: -> (request) { request.fullpath == '/monitors/lb' }
-      }
+  config.ssl_options = {
+    redirect: {
+      exclude: ->(request) { request.fullpath == '/monitors/lb' }
     }
+  }
   # end
 
   # Use the lowest log level to ensure availability of diagnostic information

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -54,9 +54,6 @@ Rails.application.configure do
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
   
-  # Allow Google Apps Script hosts
-  # config.hosts << /script\.google\.com/
-  # config.hosts << /googleusercontent\.com/
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -53,7 +53,10 @@ Rails.application.configure do
 
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
-
+  
+  # Allow Google Apps Script hosts
+  config.hosts << /script\.google\.com/
+  config.hosts << /googleusercontent\.com/
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -55,8 +55,8 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
   
   # Allow Google Apps Script hosts
-  config.hosts << /script\.google\.com/
-  config.hosts << /googleusercontent\.com/
+  # config.hosts << /script\.google\.com/
+  # config.hosts << /googleusercontent\.com/
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 

--- a/config/initializers/smtp.rb
+++ b/config/initializers/smtp.rb
@@ -3,6 +3,6 @@ ActionMailer::Base.smtp_settings = {
   password: ENV['SMTP_PASSWORD'],
   address: ENV['SMTP_ADDRESS'],
   authentication: ENV['SMTP_AUTHENTICATION'] || :none,
-  enable_starttls_auto: ENV['SMTP_ENABLE_STARTTLS_AUTO'],
+  enable_starttls_auto: ENV['SMTP_ENABLE_STARTTLS_AUTO'].to_s.downcase == 'true',
   port: ENV['SMTP_PORT'] || 25
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -270,6 +270,9 @@ en:
         cc_vip_staff_administered_meds: "Medications By Staff"
         cc_vip_sitting: "How Your Child Manages Sitting In Long Meetings (2-3 hours)"
         cc_restriction_certified: "Certify restrictions"
+        cc_restriction_certified_values:
+          CruKids_certify_WITHres: "Certified Participation WITH Restrictions"
+          CruKids_certify_NOres: "Certified Participation NO Restrictions"
       cru_student_medical_history:
         parent_agree: "Parent Agrees"
         gtky_lunch: "Their Own Lunch"
@@ -336,6 +339,9 @@ en:
         cs_vip_staff_administered_meds: "Medications By Staff"
         cs_other_special_needs: "Other Special Needs"
         cs_restriction_certified: "Certify restrictions"
+        cs_restriction_certified_values:
+          CruKids_certify_WITHres: "Certified Participation WITH Restrictions"
+          CruKids_certify_NOres: "Certified Participation NO Restrictions"
         cs_vip_developmental_age: "Developmental Age"
         cs_medications: "Medications Taken Regularly"
   active_admin:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -377,7 +377,7 @@ en:
           Check In will be held at the Hyatt Regency Milwaukee on July 13th, between 4 p.m. and 7 p.m. CT.
           <br>
           <br>
-          Team22 will have your name tags and other conference materials ready for you. Look for the “Check In Starts Here” signs and Team22 members who will point you in the right direction.
+          Team25 will have your name tags and other conference materials ready for you. Look for the “Check In Starts Here” signs and Team25 members who will point you in the right direction.
           <br>
           <br>
           We look forward to seeing you in Milwaukee this summer!
@@ -388,14 +388,14 @@ en:
           Check In will be held at the Wisconsin Center on July 16th, between 11 a.m. and 6 p.m. CT. (Enter through the main entrance at the corner of W. Wisconsin Ave. and Vel R. Phillips Ave.)
           <br>
           <br>
-          Team22 will have your name tags and other conference materials ready for you. Look for the “Check In Starts Here” signs and Team22 members who will point you in the right direction.
+          Team25 will have your name tags and other conference materials ready for you. Look for the “Check In Starts Here” signs and Team25 members who will point you in the right direction.
           <br>
           <br>
           We look forward to seeing you in Milwaukee this summer!
     rejection:
       create:
         title: "We have received your request."
-        body: "Thank you for contacting us. Team22 is working hard to answer all your questions and we hope to get back to you within 24-48 hours."
+        body: "Thank you for contacting us. Team25 is working hard to answer all your questions and we hope to get back to you within 24-48 hours."
         message: "The message you sent was:"
     status:
       show:
@@ -403,7 +403,7 @@ en:
       not_precheck_eligible:
         too_late_for_precheck:
           apology_legacy_html:
-            We are sorry. PreCheck has closed and Team22 is working hard to prepare for your arrival.
+            We are sorry. PreCheck has closed and Team25 is working hard to prepare for your arrival.
             <br>
             <br>
             Please don’t worry. You will still have a great check-in experience with the ability to confirm your information in person and get answers to your questions.
@@ -412,9 +412,9 @@ en:
             Check In will be held at the Hyatt Regency Milwaukee on July 13th, between 4 p.m. and 7 p.m. CT.
             <br>
             <br>
-            Look for the “Check In Starts Here” signs and Team22 members who will point you in the right direction.
+            Look for the “Check In Starts Here” signs and Team25 members who will point you in the right direction.
           apology_html:
-            We are sorry. PreCheck has closed and Team22 is working hard to prepare for your arrival.
+            We are sorry. PreCheck has closed and Team25 is working hard to prepare for your arrival.
             <br>
             <br>
             Please don’t worry. You will still have a great check-in experience with the ability to confirm your information in person and get answers to your questions.
@@ -423,10 +423,10 @@ en:
             Check In will be held at the Wisconsin Center on July 16th, between 11 a.m. and 6 p.m. CT. (Enter through the main entrance at the corner of W. Wisconsin Ave. and Vel R. Phillips Ave.)
             <br>
             <br>
-            Look for the “Check In Starts Here” signs and Team22 members who will point you in the right direction.
+            Look for the “Check In Starts Here” signs and Team25 members who will point you in the right direction.
         eligibility_errors_with_form:
           closing_message_html:
-            We want to help you receive PreCheck to expedite your check-in at Cru25. <b>However, if you do not receive PreCheck clearance, do not worry!</b> When you arrive at the Wisconsin Center, look for the signs and Team22 members who will direct you to the check-in area. Our team looks forward to serving you and answering your questions.
+            We want to help you receive PreCheck to expedite your check-in at Cru25. <b>However, if you do not receive PreCheck clearance, do not worry!</b> When you arrive at the Wisconsin Center, look for the signs and Team25 members who will direct you to the check-in area. Our team looks forward to serving you and answering your questions.
           changes_requested_preamble: "You've submitted a change request, your registration is undergoing review by our team."
           not_precheck_eligible_preamble: 'We are missing some conference details that will keep you from receiving PreCheck.'
           request_changes_preamble: "If you would like to request help or to send us a message, please type a message in the box below and click Submit Request and one of our team members will get in touch with you."
@@ -441,7 +441,7 @@ en:
               <ul>
                 <li>If you are an <b>employee of Cru in any capacity</b>, please type your employee ID (staff account number) or ministry chartfield in the message box below so that we can verify it and add it to your registration.</li>
                 <li>If you don’t have a chargeable staff account number or ministry chartfield that you can provide now, we can take payment <b> by credit card</b> at check-in when you arrive in Milwaukee.</li>
-                <li>If you have <b>another financial question</b> or would like to request help, type a message in the box below, click ‘Submit Request’ and a Team22 staff member will be in touch with you.</li>
+                <li>If you have <b>another financial question</b> or would like to request help, type a message in the box below, click ‘Submit Request’ and a Team25 staff member will be in touch with you.</li>
               </ul>
             children_forms_approved?_html:
               At this time, you have <b>incomplete Cru25 Kids forms</b>, which prevents eligibility for PreCheck. These can still be submitted online. Please refer to the DocuSign email packet in your email inbox to reference the remaining forms needed. <b>If you haven't received a DocuSign packet or if it is going to the wrong email box, please notify us at Cru25.crukids@cru.org so that we can make sure a packet is sent.</b>
@@ -456,7 +456,7 @@ en:
           If you see something incorrect, or something has changed since registering, click “No, I need to request changes.”
         confirm_precheck: "Yes, I accept my choices and charges"
         confirm_precheck_confirm: "Are you sure you reviewed your details and want to confirm your PreCheck?"
-        request_changes_preamble: "In the message box, please type the reason or situation that caused you to request a change so that one of our Team22 staff can help. Click the “Submit Request” button to notify us. You are still eligible to receive PreCheck until 10:00 a.m CT the day before your registered arrival date, and we will do our best to resolve your situation before you arrive in Milwaukee."
+        request_changes_preamble: "In the message box, please type the reason or situation that caused you to request a change so that one of our Team25 staff can help. Click the “Submit Request” button to notify us. You are still eligible to receive PreCheck until 10:00 a.m CT the day before your registered arrival date, and we will do our best to resolve your situation before you arrive in Milwaukee."
         request_hotel_confirmation_html: "<b>Please tell us where you chose to stay in Milwaukee.</b><br><small>(This information will help with future conference planning.)</small>"
         request_hotel_confirmation_other: "Please enter where you chose to stay in Milwaukee (Required)"
         request_changes_placeholder: "Include your change request or message in this box"
@@ -492,7 +492,7 @@ en:
         Check In will be held at the Hyatt Regency Milwaukee on July 13th, between 4 p.m. and 7 p.m. CT.
         <br>
         <br>
-        Team22 will have your name tags and other conference materials ready for you. Look for the “Check In Starts Here” signs and Team22 members who will point you in the right direction.
+        Team25 will have your name tags and other conference materials ready for you. Look for the “Check In Starts Here” signs and Team25 members who will point you in the right direction.
         <br>
         <br>
         We look forward to seeing you in Milwaukee this summer!
@@ -503,7 +503,7 @@ en:
         Check In will be held at the Wisconsin Center on July 16th, between 11 a.m. and 6 p.m. CT. (Enter through the main entrance at the corner of W. Wisconsin Ave. and Vel R. Phillips Ave.)
         <br>
         <br>
-        Team22 will have your name tags and other conference materials ready for you. Look for the “Check In Starts Here” signs and Team22 members who will point you in the right direction.
+        Team25 will have your name tags and other conference materials ready for you. Look for the “Check In Starts Here” signs and Team25 members who will point you in the right direction.
         <br>
         <br>
         We look forward to seeing you in Milwaukee this summer!
@@ -546,14 +546,14 @@ en:
       <br>
       Thank you,
       <br>
-      Team22
+      Team25
       <br>
       <br>
       P.S. We want to help you receive PreCheck to expedite your check-in at Cru25. We will send a reminder each day until you have successfully resolved your conference details.
     video_html:
       Watch a fun video, learn more about the PreCheck process and see FAQ <a href="https://www.cru.org/Cru25/precheck/">here</a>.
     not_eligible_preamble_html:
-      Team22 is pleased to offer you <b>PreCheck</b> at Cru25.
+      Team25 is pleased to offer you <b>PreCheck</b> at Cru25.
       This allows you to confirm your conference details ahead of time for express check-in in Milwaukee.
       <br>
       We desire for you to receive PreCheck so that your time can be spent connecting with friends, settling in and enjoying the Milwaukee area.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -426,7 +426,7 @@ en:
             Look for the “Check In Starts Here” signs and Team22 members who will point you in the right direction.
         eligibility_errors_with_form:
           closing_message_html:
-            We want to help you receive PreCheck to expedite your check-in at Cru22. <b>However, if you do not receive PreCheck clearance, do not worry!</b> When you arrive at the Wisconsin Center, look for the signs and Team22 members who will direct you to the check-in area. Our team looks forward to serving you and answering your questions.
+            We want to help you receive PreCheck to expedite your check-in at Cru25. <b>However, if you do not receive PreCheck clearance, do not worry!</b> When you arrive at the Wisconsin Center, look for the signs and Team22 members who will direct you to the check-in area. Our team looks forward to serving you and answering your questions.
           changes_requested_preamble: "You've submitted a change request, your registration is undergoing review by our team."
           not_precheck_eligible_preamble: 'We are missing some conference details that will keep you from receiving PreCheck.'
           request_changes_preamble: "If you would like to request help or to send us a message, please type a message in the box below and click Submit Request and one of our team members will get in touch with you."
@@ -444,13 +444,13 @@ en:
                 <li>If you have <b>another financial question</b> or would like to request help, type a message in the box below, click ‘Submit Request’ and a Team22 staff member will be in touch with you.</li>
               </ul>
             children_forms_approved?_html:
-              At this time, you have <b>incomplete Cru22 Kids forms</b>, which prevents eligibility for PreCheck. These can still be submitted online. Please refer to the DocuSign email packet in your email inbox to reference the remaining forms needed. <b>If you haven't received a DocuSign packet or if it is going to the wrong email box, please notify us at cru22.crukids@cru.org so that we can make sure a packet is sent.</b>
+              At this time, you have <b>incomplete Cru25 Kids forms</b>, which prevents eligibility for PreCheck. These can still be submitted online. Please refer to the DocuSign email packet in your email inbox to reference the remaining forms needed. <b>If you haven't received a DocuSign packet or if it is going to the wrong email box, please notify us at Cru25.crukids@cru.org so that we can make sure a packet is sent.</b>
               <br>
               <br>
               Once the forms are signed and submitted using the steps outlined in the email, the CruKids team will notify you that they are complete. You have up to 24 hours before your arrival to complete this step and become eligible for PreCheck.
       precheck_eligible:
         financial_summary_preamble_html:
-          Please carefully review your Cru22 details. If your personal/family registration information and conference cost breakdown are correct, click “Yes, I accept my choices and charges”. This opportunity to receive PreCheck will only be available until 10:00 a.m. CT the day before your registered arrival date.
+          Please carefully review your Cru25 details. If your personal/family registration information and conference cost breakdown are correct, click “Yes, I accept my choices and charges”. This opportunity to receive PreCheck will only be available until 10:00 a.m. CT the day before your registered arrival date.
           <br>
           <br>
           If you see something incorrect, or something has changed since registering, click “No, I need to request changes.”
@@ -507,14 +507,14 @@ en:
         <br>
         <br>
         We look forward to seeing you in Milwaukee this summer!
-      onsite_confirmed: "Welcome to Cru22"
+      onsite_confirmed: "Welcome to Cru25"
       summary_preamble: "Below is your conference registration summary."
       contact_list_preamble: "For questions regarding:"
       contact_list_html: '<ul>
-          <li>Kids Care / Kids Camp, please contact <a href="mailto:Cru22.CruKids@cru.org">Cru22.CruKids@cru.org</a> </li>
-          <li>CruStu, please contact <a href="mailto:Cru22.CruStu@cru.org">Cru22.CruStu@cru.org</a></li>
-          <li>Finances, please contact <a href="mailto:Cru22.Finance@cru.org">Cru22.Finance@cru.org</a></li>
-          <li>Anything else, please contact <a href="mailto:Cru22.Info@cru.org">Cru22.Info@cru.org</a></li>
+          <li>Kids Care / Kids Camp, please contact <a href="mailto:Cru25.CruKids@cru.org">Cru25.CruKids@cru.org</a> </li>
+          <li>CruStu, please contact <a href="mailto:Cru25.CruStu@cru.org">Cru25.CruStu@cru.org</a></li>
+          <li>Finances, please contact <a href="mailto:Cru25.Finance@cru.org">Cru25.Finance@cru.org</a></li>
+          <li>Anything else, please contact <a href="mailto:Cru25.Info@cru.org">Cru25.Info@cru.org</a></li>
         </ul>'
       signature_html: "<p>Sincerely,<br><br>%{conference} Team</p>"
 
@@ -522,7 +522,7 @@ en:
     confirm_charges:
       subject: "%{conference} - PreCheck Eligible"
       body_html:
-        <p>Good news! Your Cru22 registration is <b>eligible for PreCheck.</b>
+        <p>Good news! Your Cru25 registration is <b>eligible for PreCheck.</b>
         <br>
         <br>
         You can confirm your conference details ahead of time and qualify for express check-in at the Wisconsin Center. We desire for you to receive PreCheck so that your time can be spent connecting with friends, settling in, and enjoying the downtown Milwaukee area.
@@ -549,11 +549,11 @@ en:
       Team22
       <br>
       <br>
-      P.S. We want to help you receive PreCheck to expedite your check-in at Cru22. We will send a reminder each day until you have successfully resolved your conference details.
+      P.S. We want to help you receive PreCheck to expedite your check-in at Cru25. We will send a reminder each day until you have successfully resolved your conference details.
     video_html:
-      Watch a fun video, learn more about the PreCheck process and see FAQ <a href="https://www.cru.org/cru22/precheck/">here</a>.
+      Watch a fun video, learn more about the PreCheck process and see FAQ <a href="https://www.cru.org/Cru25/precheck/">here</a>.
     not_eligible_preamble_html:
-      Team22 is pleased to offer you <b>PreCheck</b> at Cru22.
+      Team22 is pleased to offer you <b>PreCheck</b> at Cru25.
       This allows you to confirm your conference details ahead of time for express check-in in Milwaukee.
       <br>
       We desire for you to receive PreCheck so that your time can be spent connecting with friends, settling in and enjoying the Milwaukee area.
@@ -568,7 +568,7 @@ en:
         <br>
         When your balance is paid in full, you will receive another email indicating that you are now eligible for PreCheck with the opportunity to review and confirm your conference information.
       children_forms_approved?_html:
-        At this time, you have <b>incomplete Cru22 Kids forms</b> which prevents eligibility for PreCheck.
+        At this time, you have <b>incomplete Cru25 Kids forms</b> which prevents eligibility for PreCheck.
         <br>
         We would like to help you submit the forms before you arrive so that you can receive PreCheck.
         <br>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -233,13 +233,17 @@ en:
           list: 'List'
       childcare_medical_history:
         allergy: "Allergies"
+        cc_allergies: "Allergies"
+        cc_medi_allergy: "Medication Allergies"
         food_intolerance: "Food Intolerances"
         chronic_health: "Chronic Health Issues"
         chronic_health_addl: "Chronic Health Additional Information"
         medications: "Medications Taken Regularly"
         immunizations: "Current Immunizations"
+        non_immunizations: "May include non-immunized children"
         health_misc: "Misc Health Issues"
         restrictions: "Participation Restrictions"
+        other_special_needs: "Other Special Needs"
         vip_meds: Medications Taken During Program Hours
         vip_dev: "Health And Developmental Needs"
         vip_strengths: "Strengths"
@@ -319,6 +323,9 @@ en:
         cs_vip_hobby: "Student’s Favorite Activity, Hobby Or Interest"
         cs_vip_buddy: "Someone In The Program To Place In The Same Group As Your Student During CruStu and/or The Getaway"
         cs_vip_addl_info: "Please Explain Anything Else You Would Like Us To Know About Your Student"
+        cs_allergies: "Allergies"
+        cs_chronic_health: "Chronic Health Issues"
+        cs_restrictions: "Participation Restrictions"
 
   active_admin:
     dashboard:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -233,7 +233,7 @@ en:
           html: 'HTML'
           list: 'List'
       childcare_medical_history:
-        allergy: "Allergies"
+        allergy: "Other Allergy Information"
         cc_allergies: "Allergies"
         cc_medi_allergy: "Medication Allergies"
         food_intolerance: "Food Intolerances"
@@ -244,7 +244,7 @@ en:
         non_immunizations: "May include non-immunized children"
         health_misc: "Misc Health Issues"
         restrictions: "Participation Restrictions"
-        other_special_needs: "Other Special Needs"
+        cc_other_special_needs: "Other Special Needs"
         vip_meds: Medications Taken During Program Hours
         vip_dev: "Health And Developmental Needs"
         vip_strengths: "Strengths"
@@ -266,6 +266,9 @@ en:
         sunscreen_self: "Can apply sunscreen to self"
         sunscreen_assisted: "Can be assisted to apply sunscreen"
         sunscreen_provided: "OK to use Care/Camp sunscreen"
+        cc_vip_developmental_age: "Developmental Age"
+        cc_vip_staff_administered_meds: "Medications By Staff"
+        cc_vip_sitting: "How Your Child Manages Sitting In Long Meetings (2-3 hours)"
       cru_student_medical_history:
         parent_agree: "Parent Agrees"
         gtky_lunch: "Their Own Lunch"
@@ -327,7 +330,13 @@ en:
         cs_allergies: "Allergies"
         cs_chronic_health: "Chronic Health Issues"
         cs_restrictions: "Participation Restrictions"
-
+        crustu_forms_acknowledged: "Acknowledges That The Forms Are Complete"
+        cs_chronic_health_addl: "Chronic Health Additional Information"
+        cs_vip_staff_administered_meds: "Medications By Staff"
+        cs_other_special_needs: "Other Special Needs"
+        cs_restriction_certified: "Certify restrictions"
+        cs_vip_developmental_age: "Developmental Age"
+        cs_medications: "Medications Taken Regularly"
   active_admin:
     dashboard:
       title: "Dashboard"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,6 +63,7 @@ en:
       child:
         forms_approved: "Forms Approved"
         forms_approved_by: "Approver Initials"
+        uuid: "Unique ID"
         childcare: "Kids Care Class"
         childcare_suffixes:
           childcare: "%{label} Cru Kids"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -269,6 +269,7 @@ en:
         cc_vip_developmental_age: "Developmental Age"
         cc_vip_staff_administered_meds: "Medications By Staff"
         cc_vip_sitting: "How Your Child Manages Sitting In Long Meetings (2-3 hours)"
+        cc_restriction_certified: "Certify restrictions"
       cru_student_medical_history:
         parent_agree: "Parent Agrees"
         gtky_lunch: "Their Own Lunch"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
 
   authenticated_constraint = lambda do |request|
-    Authenticatable::SessionUser.new(request.session).signed_into_cas?
+    Authenticatable::SessionUser.new(request.session).signed_into_okta?
   end
 
   constraints authenticated_constraint do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,9 @@ Rails.application.routes.draw do
 
   post '/', to: "application#consume_okta"
 
+  post '/child_form_approval/:uid', to: 'external_forms#approve', as: :approve_external_form
+  delete '/child_form_approval/:uid', to: 'external_forms#disapprove', as: :disapprove_external_form
+
   namespace :precheck do
     get ':token', to: 'status#show', as: :status
     post ':token/confirmation', to: 'confirmation#create', as: :confirmation

--- a/db/development_records.rb
+++ b/db/development_records.rb
@@ -25,9 +25,9 @@ class SeedDevelopmentRecords
   # +test/fixtures/+
   CONFERENCES = [
     'Coach or Instructor',
-    'Cru22',
-    'Cru25',
+    'Cru25',    
     'Legacy',
+    'Team25',
     'Team22',
     'Institute of Biblical Studies TA',
     'Legacy Track (Staff 60 years of age and older)',
@@ -1060,7 +1060,8 @@ class SeedDevelopmentRecords
     'WWC',
     'YALE',
     'ZAF',
-    'ZAF4'
+    'ZAF4',
+    'CMMO0503'
   ].freeze
 
   def initialize

--- a/db/development_records.rb
+++ b/db/development_records.rb
@@ -28,7 +28,6 @@ class SeedDevelopmentRecords
     'Cru25',    
     'Legacy',
     'Team25',
-    'Team22',
     'Institute of Biblical Studies TA',
     'Legacy Track (Staff 60 years of age and older)',
     'Legal Internship Participant',

--- a/db/migrate/20250426233016_add_medi_allergies_to_childcare_medical_histories.rb
+++ b/db/migrate/20250426233016_add_medi_allergies_to_childcare_medical_histories.rb
@@ -1,25 +1,14 @@
 class AddMediAllergiesToChildcareMedicalHistories < ActiveRecord::Migration[7.1]
   def change
-    add_column :childcare_medical_histories, :cc_medi_allergy, :text, null: true
-    add_column :childcare_medical_histories, :cc_allergies, :string, array: true, default: [], null: true
+    add_column :childcare_medical_histories, :medi_allergy, :text, null: true
+    add_column :childcare_medical_histories, :allergies, :string, array: true, default: [], null: true
     add_column :childcare_medical_histories, :non_immunizations, :string, array: true, default: [], null: true
-    add_column :childcare_medical_histories, :cc_restriction_certified, :string, array: true, default: [], null: true    
-    add_column :childcare_medical_histories, :cc_vip_sitting, :string, null: true
-    add_column :childcare_medical_histories, :cc_other_special_needs, :string, null: true
-    add_column :childcare_medical_histories, :cc_vip_staff_administered_meds, :string, null: true
-    add_column :childcare_medical_histories, :cc_vip_developmental_age, :string, null: true
+    add_column :childcare_medical_histories, :restriction_certified, :string, array: true, default: [], null: true    
+    add_column :childcare_medical_histories, :vip_developmental_age, :integer, null: true
+    add_column :childcare_medical_histories, :cc_vip_sitting, :text, null: true
 
-    
+    add_column :cru_student_medical_histories, :med_allergy_multi, :text, null: true
     add_column :cru_student_medical_histories, :crustu_forms_acknowledged, :string, array: true, default: [], null: true
-    add_column :cru_student_medical_histories, :cs_allergies, :string, array: true, default: [], null: true
-    add_column :cru_student_medical_histories, :cs_restriction_certified, :string, array: true, default: [], null: true        
-    add_column :cru_student_medical_histories, :cs_other_special_needs, :text, null: true
-    add_column :cru_student_medical_histories, :cs_vip_staff_administered_meds, :text, null: true
-    add_column :cru_student_medical_histories, :cs_chronic_health, :string, array: true, default: [], null: true    
-    add_column :cru_student_medical_histories, :cs_medications, :string, null: true   
-    add_column :cru_student_medical_histories, :cs_vip_developmental_age, :string, null: true
-    add_column :cru_student_medical_histories, :cs_restrictions, :string, null: true
-
     add_column :people, :tracking_id, :string, null: true
 
   end

--- a/db/migrate/20250507205321_add_uuid_to_people.rb
+++ b/db/migrate/20250507205321_add_uuid_to_people.rb
@@ -1,0 +1,7 @@
+class AddUuidToPeople < ActiveRecord::Migration[7.1]
+  def change
+    enable_extension 'pgcrypto' unless extension_enabled?('pgcrypto')
+    add_column :people, :uuid, :uuid, default: 'gen_random_uuid()', null: false
+    add_index :people, :uuid, unique: true
+  end
+end

--- a/db/migrate/20250508154443_backfill_people_uuid.rb
+++ b/db/migrate/20250508154443_backfill_people_uuid.rb
@@ -1,0 +1,18 @@
+class BackfillPeopleUuid < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!  # avoid long locks for large tables
+
+  def up
+    say_with_time "Backfilling UUIDs for existing people records..." do
+      Person.reset_column_information
+      Person.where(uuid: nil).find_in_batches(batch_size: 1000) do |batch|
+        batch.each do |person|
+          person.update_column(:uuid, SecureRandom.uuid)
+        end
+      end
+    end
+  end
+
+  def down
+    # Clear the UUIDs (not usually needed)    
+  end
+end

--- a/db/migrate/20250514044430_sync_childcare_and_cru_student_medical_fields.rb
+++ b/db/migrate/20250514044430_sync_childcare_and_cru_student_medical_fields.rb
@@ -1,0 +1,31 @@
+class SyncChildcareAndCruStudentMedicalFields < ActiveRecord::Migration[7.1]
+  def change
+    # --- Remove outdated columns ---
+    remove_column :childcare_medical_histories, :medi_allergy, :text
+    remove_column :childcare_medical_histories, :allergies, :string, array: true
+    remove_column :childcare_medical_histories, :restriction_certified, :string, array: true
+    remove_column :childcare_medical_histories, :vip_developmental_age, :integer
+    remove_column :childcare_medical_histories, :other_special_needs, :text
+    remove_column :childcare_medical_histories, :cc_vip_sitting, :text   # will re-add as string    
+
+    remove_column :cru_student_medical_histories, :med_allergy_multi, :string, array: true
+
+    # --- Add updated/renamed fields ---
+    add_column :childcare_medical_histories, :cc_medi_allergy, :text
+    add_column :childcare_medical_histories, :cc_allergies, :string, array: true, default: [], null: true
+    add_column :childcare_medical_histories, :cc_restriction_certified, :string, array: true, default: [], null: true
+    add_column :childcare_medical_histories, :cc_vip_sitting, :string
+    add_column :childcare_medical_histories, :cc_other_special_needs, :string
+    add_column :childcare_medical_histories, :cc_vip_staff_administered_meds, :string
+    add_column :childcare_medical_histories, :cc_vip_developmental_age, :string    
+
+    add_column :cru_student_medical_histories, :cs_allergies, :string, array: true, default: [], null: true
+    add_column :cru_student_medical_histories, :cs_restriction_certified, :string, array: true, default: [], null: true
+    add_column :cru_student_medical_histories, :cs_other_special_needs, :text
+    add_column :cru_student_medical_histories, :cs_vip_staff_administered_meds, :text
+    add_column :cru_student_medical_histories, :cs_chronic_health, :string, array: true, default: [], null: true
+    add_column :cru_student_medical_histories, :cs_medications, :string
+    add_column :cru_student_medical_histories, :cs_vip_developmental_age, :string
+    add_column :cru_student_medical_histories, :cs_restrictions, :string
+  end
+end

--- a/db/migrate/20250515040956_change_crustu_forms_acknowledged_to_string.rb
+++ b/db/migrate/20250515040956_change_crustu_forms_acknowledged_to_string.rb
@@ -1,0 +1,11 @@
+class ChangeCrustuFormsAcknowledgedToString < ActiveRecord::Migration[7.1]
+  def up
+    change_column :cru_student_medical_histories, :crustu_forms_acknowledged, :string, default: '', null: true
+    add_column :cru_student_medical_histories, :cs_chronic_health_addl, :text
+  end
+
+  def down
+    # Revert crustu_forms_acknowledged back to string array    
+    remove_column :cru_student_medical_histories, :cs_chronic_health_addl
+  end
+end

--- a/db/migrate/20250516190555_change_restriction_fields_datatype.rb
+++ b/db/migrate/20250516190555_change_restriction_fields_datatype.rb
@@ -1,0 +1,25 @@
+class ChangeRestrictionFieldsDatatype < ActiveRecord::Migration[7.1]
+  def up
+    remove_column :cru_student_medical_histories, :cs_restriction_certified
+    add_column :cru_student_medical_histories, :cs_restriction_certified, :string    
+
+    remove_column :childcare_medical_histories, :cc_restriction_certified
+    add_column :childcare_medical_histories, :cc_restriction_certified, :string
+
+    add_column :people, :childcare_cancellation_fee, :boolean, default: false, null: false
+    add_column :people, :childcare_late_fee, :boolean, default: false, null: false
+    add_column :people, :county, :string
+  end
+
+  def down
+    remove_column :cru_student_medical_histories, :cs_restriction_certified
+    add_column :cru_student_medical_histories, :cs_restriction_certified, :string, array: true, default: [], null: true    
+
+    remove_column :childcare_medical_histories, :cc_restriction_certified
+    add_column :childcare_medical_histories, :cc_restriction_certified, :string, array: true, default: [], null: true
+
+    remove_column :people, :childcare_cancellation_fee
+    remove_column :people, :childcare_late_fee
+    remove_column :people, :county
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -79,7 +79,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_16_190555) do
     t.string "health_misc", default: [], array: true
     t.string "vip_comm", default: [], array: true
     t.string "vip_stress", default: [], array: true
-    t.string "non_immunizations", array: true
+    t.string "non_immunizations", default: [], array: true
     t.text "cc_medi_allergy"
     t.string "cc_allergies", default: [], array: true
     t.string "cc_vip_sitting"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_08_154443) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_15_040956) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -79,11 +79,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_08_154443) do
     t.string "health_misc", default: [], array: true
     t.string "vip_comm", default: [], array: true
     t.string "vip_stress", default: [], array: true
-    t.text "medi_allergy"
-    t.string "allergies", default: [], array: true
-    t.string "restriction_certified", default: [], array: true
-    t.integer "vip_developmental_age"
-    t.text "other_special_needs"
     t.text "cc_medi_allergy"
     t.string "cc_allergies", default: [], array: true
     t.string "non_immunizations", default: [], array: true
@@ -247,16 +242,16 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_08_154443) do
     t.string "cs_health_misc", default: [], array: true
     t.string "cs_vip_comm", default: [], array: true
     t.string "cs_vip_stress", default: [], array: true
-    t.string "med_allergy_multi", default: [], array: true
-    t.string "crustu_forms_acknowledged", default: [], array: true
+    t.string "crustu_forms_acknowledged", default: ""
     t.string "cs_allergies", default: [], array: true
-    t.string "cs_restriction_certified", default: [], array: true
     t.text "cs_other_special_needs"
     t.text "cs_vip_staff_administered_meds"
     t.string "cs_chronic_health", default: [], array: true
     t.string "cs_medications"
     t.string "cs_vip_developmental_age"
     t.string "cs_restrictions"
+    t.string "cs_restriction_certified", default: [], array: true
+    t.text "cs_chronic_health_addl"
     t.index ["child_id"], name: "index_cru_student_medical_histories_on_child_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_26_233016) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_08_154443) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "active_admin_comments", id: :serial, force: :cascade do |t|
@@ -78,6 +79,11 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_26_233016) do
     t.string "health_misc", default: [], array: true
     t.string "vip_comm", default: [], array: true
     t.string "vip_stress", default: [], array: true
+    t.text "medi_allergy"
+    t.string "allergies", default: [], array: true
+    t.string "restriction_certified", default: [], array: true
+    t.integer "vip_developmental_age"
+    t.text "other_special_needs"
     t.text "cc_medi_allergy"
     t.string "cc_allergies", default: [], array: true
     t.string "non_immunizations", default: [], array: true
@@ -241,6 +247,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_26_233016) do
     t.string "cs_health_misc", default: [], array: true
     t.string "cs_vip_comm", default: [], array: true
     t.string "cs_vip_stress", default: [], array: true
+    t.string "med_allergy_multi", default: [], array: true
     t.string "crustu_forms_acknowledged", default: [], array: true
     t.string "cs_allergies", default: [], array: true
     t.string "cs_restriction_certified", default: [], array: true
@@ -428,12 +435,14 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_26_233016) do
     t.integer "spouse_id"
     t.string "forms_approved_by"
     t.string "tracking_id"
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.index ["childcare_id"], name: "index_people_on_childcare_id"
     t.index ["middle_name"], name: "index_people_on_middle_name"
     t.index ["seminary_id"], name: "index_people_on_seminary_id"
     t.index ["spouse_id"], name: "index_people_on_spouse_id"
     t.index ["student_number"], name: "index_people_on_student_number"
     t.index ["type"], name: "index_people_on_type"
+    t.index ["uuid"], name: "index_people_on_uuid", unique: true
   end
 
   create_table "precheck_email_tokens", id: false, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_15_040956) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_16_190555) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -79,14 +79,14 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_15_040956) do
     t.string "health_misc", default: [], array: true
     t.string "vip_comm", default: [], array: true
     t.string "vip_stress", default: [], array: true
+    t.string "non_immunizations", array: true
     t.text "cc_medi_allergy"
     t.string "cc_allergies", default: [], array: true
-    t.string "non_immunizations", default: [], array: true
-    t.string "cc_restriction_certified", default: [], array: true
     t.string "cc_vip_sitting"
     t.string "cc_other_special_needs"
     t.string "cc_vip_staff_administered_meds"
     t.string "cc_vip_developmental_age"
+    t.string "cc_restriction_certified"
     t.index ["child_id"], name: "index_childcare_medical_histories_on_child_id"
   end
 
@@ -250,8 +250,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_15_040956) do
     t.string "cs_medications"
     t.string "cs_vip_developmental_age"
     t.string "cs_restrictions"
-    t.string "cs_restriction_certified", default: [], array: true
     t.text "cs_chronic_health_addl"
+    t.string "cs_restriction_certified"
     t.index ["child_id"], name: "index_cru_student_medical_histories_on_child_id"
   end
 
@@ -431,6 +431,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_15_040956) do
     t.string "forms_approved_by"
     t.string "tracking_id"
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
+    t.boolean "childcare_cancellation_fee", default: false, null: false
+    t.boolean "childcare_late_fee", default: false, null: false
+    t.string "county"
     t.index ["childcare_id"], name: "index_people_on_childcare_id"
     t.index ["middle_name"], name: "index_people_on_middle_name"
     t.index ["seminary_id"], name: "index_people_on_seminary_id"

--- a/db/user_variables.rb
+++ b/db/user_variables.rb
@@ -63,9 +63,9 @@ class SeedUserVariables
     
 
     # Conference
-    conference_id:       { value_type: :string, code: :CONFID, value: 'Cru22', description: 'A string containing the name of the conference.' },
+    conference_id:       { value_type: :string, code: :CONFID, value: 'Cru25', description: 'A string containing the name of the conference.' },
     support_email:       { value_type: :string, code: :SUPPORTEMAIL, value: 'help@cru.org', description: 'Support email address' },
-    conference_logo_url: { value_type: :string, code: :CONFLOGO, value: 'https://www.cru.org/content/dam/cru/cru22/cru22-logo-thumbnail.png', description: 'Conference logo URL' },
+    conference_logo_url: { value_type: :string, code: :CONFLOGO, value: 'https://www.cru.org/content/dam/cru/Cru25/Cru25-logo-thumbnail.png', description: 'Conference logo URL' },
 
     # Mail
     mail_interceptor_email_addresses: { value_type: :list, code: :MAIL_INTERCEPTOR_EMAILS, value: 'interceptor_one@example.com, interceptor_two@example.com',

--- a/test/controllers/precheck/confirmation_controller_test.rb
+++ b/test/controllers/precheck/confirmation_controller_test.rb
@@ -31,7 +31,7 @@ class Precheck::ConfirmationControllerTest < ControllerTestCase
     assert_equal family.reload.precheck_status, 'approved'
 
     last_email = ActionMailer::Base.deliveries.last
-    assert_equal 'Cru22 PreCheck Summary', last_email.subject
+    assert_equal 'Cru25 PreCheck Summary', last_email.subject
     assert_equal [family.attendees.first.email], last_email.to
   end
 

--- a/test/integration/precheck/status/show_test.rb
+++ b/test/integration/precheck/status/show_test.rb
@@ -78,7 +78,7 @@ class Precheck::StatusController::ShowTest < IntegrationTest
 
     travel_to 7.days.from_now.beginning_of_day do
       visit precheck_status_path(token: @eligible_family.precheck_email_token.token)
-      assert_text 'We are sorry. PreCheck has closed and Team22 is working hard to prepare for your arrival.'
+      assert_text 'We are sorry. PreCheck has closed and Team25 is working hard to prepare for your arrival.'
     end
   end
 end

--- a/test/integration/precheck/status/show_test.rb
+++ b/test/integration/precheck/status/show_test.rb
@@ -66,8 +66,8 @@ class Precheck::StatusController::ShowTest < IntegrationTest
     @eligible_family.update!(precheck_status: :pending_approval)
     @eligible_family.check_in!
     visit precheck_status_path(token: @eligible_family.precheck_email_token.token)
-    assert_text 'Welcome to Cru22'
-    assert has_no_text? 'received Cru22 PreCheck'
+    assert_text 'Welcome to Cru25'
+    assert has_no_text? 'received Cru25 PreCheck'
   end
 
   test '#show too late for precheck' do

--- a/test/mailers/family_mailer_test.rb
+++ b/test/mailers/family_mailer_test.rb
@@ -15,7 +15,7 @@ class FamilyMailerTest < ActionMailer::TestCase
 
     assert_equal ['no-reply@cru.org'], email.from
     assert_equal @family.attendees.map(&:email).sort, email.to.sort
-    assert_equal 'Cru22 PreCheck Summary', email.subject
+    assert_equal 'Cru25 PreCheck Summary', email.subject
     assert_match 'Remaining Balance Due', email.body.to_s
   end
 end

--- a/test/mailers/precheck_mailer_test.rb
+++ b/test/mailers/precheck_mailer_test.rb
@@ -15,7 +15,7 @@ class PrecheckMailerTest < MailTestCase
 
     assert_equal ['no-reply@cru.org'], email.from
     assert_equal [UserVariable[:support_email]], email.to
-    assert_equal "Cru22 PreCheck Changes Requested for Family #{@family.to_s}", email.subject
+    assert_equal "Cru25 PreCheck Changes Requested for Family #{@family.to_s}", email.subject
     assert_match 'my name was mispelled', email.body.to_s
 
     @family.attendees.each do |attendee|
@@ -34,7 +34,7 @@ class PrecheckMailerTest < MailTestCase
 
       assert_equal ['no-reply@cru.org'], email.from
       assert_equal @family.attendees.map(&:email).sort, email.to.sort
-      assert_equal 'Cru22 - PreCheck Eligible', email.subject
+      assert_equal 'Cru25 - PreCheck Eligible', email.subject
     end
   end
 
@@ -56,7 +56,7 @@ class PrecheckMailerTest < MailTestCase
 
     assert_equal ['no-reply@cru.org'], email.from
     assert_equal @family.attendees.map(&:email).sort, email.to.sort
-    assert_equal 'Cru22 - Unconfirmed PreCheck Details', email.subject
+    assert_equal 'Cru25 - Unconfirmed PreCheck Details', email.subject
     assert_match 'children_forms_not_approved', email.body.to_s
     assert_match @family.precheck_email_token.token, email.body.to_s
   end

--- a/test/services/childcare/send_docusign_envelope_test.rb
+++ b/test/services/childcare/send_docusign_envelope_test.rb
@@ -10,7 +10,7 @@ class Childcare::SendDocusignEnvelopeTest < ServiceTestCase
   end
 
   stub_user_variable child_age_cutoff: 6.months.from_now.to_date,
-                     conference_id: 'Cru22'
+                     conference_id: 'Cru25'
 
   test 'valid payload' do
     VCR.use_cassette('docusign/childcare_send_valid_payload') do

--- a/test/services/import/import_people_from_spreadsheet_test.rb
+++ b/test/services/import/import_people_from_spreadsheet_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Import::ImportPeopleFromSpreadsheetTest < ServiceTestCase
   def around(&blk)
-    conference = Conference.find_or_initialize_by(name: 'Cru22')
+    conference = Conference.find_or_initialize_by(name: 'Cru25')
     conference.save if conference.new_record?
 
     ministry = Ministry.find_or_initialize_by(code: 'FL33230')

--- a/test/services/precheck/mail_delivery_service_test.rb
+++ b/test/services/precheck/mail_delivery_service_test.rb
@@ -28,7 +28,7 @@ class Precheck::MailDeliveryServiceTest < ServiceTestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['no-reply@cru.org'], email.from
     assert_equal [@attendee.email], email.to
-    assert_equal 'Cru22 - PreCheck Eligible', email.subject
+    assert_equal 'Cru25 - PreCheck Eligible', email.subject
     assert_match 'Review Registration', email.body.to_s
   end
 
@@ -42,8 +42,8 @@ class Precheck::MailDeliveryServiceTest < ServiceTestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['no-reply@cru.org'], email.from
     assert_equal [@attendee.email], email.to
-    assert_equal 'Cru22 - Unconfirmed PreCheck Details', email.subject
-    assert_match 'incomplete Cru22 Kids forms', email.body.to_s
+    assert_equal 'Cru25 - Unconfirmed PreCheck Details', email.subject
+    assert_match 'incomplete Cru25 Kids forms', email.body.to_s
   end
 
   test '#deliver_pending_approval_mail does not deliver if status is not pending_approval' do
@@ -82,7 +82,7 @@ class Precheck::MailDeliveryServiceTest < ServiceTestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['no-reply@cru.org'], email.from
     assert_equal ['help@cru.org'], email.to
-    assert_equal "Cru22 PreCheck Changes Requested for Family #{@eligible_family.to_s}", email.subject
+    assert_equal "Cru25 PreCheck Changes Requested for Family #{@eligible_family.to_s}", email.subject
     assert_match 'The following family has used the PreCheck form to request changes to their registration', email.body.to_s
     assert_match 'Hello World', email.body.to_s
   end

--- a/test/services/precheck/updated_family_status_service_test.rb
+++ b/test/services/precheck/updated_family_status_service_test.rb
@@ -37,7 +37,7 @@ class Precheck::UpdatedFamilyStatusServiceTest < ServiceTestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['no-reply@cru.org'], email.from
     assert_equal [@attendee_one.email, @attendee_two.email], email.to
-    assert_equal 'Cru22 - PreCheck Eligible', email.subject
+    assert_equal 'Cru25 - PreCheck Eligible', email.subject
     assert_match 'Review Registration', email.body.to_s
   end
 
@@ -81,7 +81,7 @@ class Precheck::UpdatedFamilyStatusServiceTest < ServiceTestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['no-reply@cru.org'], email.from
     assert_equal @family.attendees.map(&:email).sort, email.to.sort
-    assert_equal 'Cru22 PreCheck Summary', email.subject
+    assert_equal 'Cru25 PreCheck Summary', email.subject
     assert_match 'Your <b>PreCheck</b> has been completed - you have now received <b>PreCheck</b>.', email.body.to_s
   end
 
@@ -105,7 +105,7 @@ class Precheck::UpdatedFamilyStatusServiceTest < ServiceTestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['no-reply@cru.org'], email.from
     assert_equal [UserVariable[:support_email]], email.to
-    assert_equal "Cru22 PreCheck Changes Requested for Family #{@family.to_s}", email.subject
+    assert_equal "Cru25 PreCheck Changes Requested for Family #{@family.to_s}", email.subject
     assert_match 'Test 1 2 3', email.body.to_s
   end
 
@@ -120,7 +120,7 @@ class Precheck::UpdatedFamilyStatusServiceTest < ServiceTestCase
     email = ActionMailer::Base.deliveries.last
     assert_equal ['no-reply@cru.org'], email.from
     assert_equal [UserVariable[:support_email]], email.to
-    assert_equal "Cru22 PreCheck Changes Requested for Family #{@family.to_s}", email.subject
+    assert_equal "Cru25 PreCheck Changes Requested for Family #{@family.to_s}", email.subject
     assert_match 'Test 1 2 3', email.body.to_s
   end
 end


### PR DESCRIPTION
## Summary

### Key Changes

- **DocuSign Template Enhancements**
  - Expanded support from **3 to 6 templates** to handle VIP and non-VIP flows.
  - Template logic now based on:
    - **Grade level** (Child, Kids, or CruStu)
  - Grade level category breakdown:
    - **0 to 5 Kindergarten** → Child templates
    - **Grade 1 to 6** → Kids templates
    - **Grade 7 and above** → Cru Kids (Teens) templates

- **UUID Enhancements**
  - Added `uuid` field to child models with default `gen_random_uuid()`.
  - UUIDs are now used as reference keys for external API triggers (e.g., Google Apps Script).

- **New External API for Forms Approval**
  - Added endpoint for triggering child form approvals via GAS.

- **Post Rails 7 Upgrade Fixes**
  - Fixed strong parameters issue affecting file uploads (e.g., `.permit(...).to_h.with_indifferent_access`).
  - Resolved broken import workflows for ministries, hierarchy, staff numbers, etc.
  - Ensured all spreadsheet jobs handle optional flags like `skip_first`.

- **Content & Sample Data Updates**
  - Updated sample user data and email text references from **Cru22** to **Cru25**.

### Testing

- Verified all 6 DocuSign templates trigger and pre-fill as expected
- Confirmed GAS API integration returns appropriate status codes (403/200)
- CSV import tested for various edge cases including UUID and optional headers
- All background jobs enqueue and process correctly post-upload
