### PR TITLE
Fix Sidekiq Cron job error by adding a Sidekiq worker wrapper for ActiveJob

### DIFF
--- a/app/workers/nightly_precheck_mailer_worker.rb
+++ b/app/workers/nightly_precheck_mailer_worker.rb
@@ -1,0 +1,7 @@
+class NightlyPrecheckMailerWorker
+  include Sidekiq::Worker
+
+  def perform
+    NightlyPrecheckMailerJob.perform_later
+  end
+end

--- a/config/initializers/sidekiq_cron.rb
+++ b/config/initializers/sidekiq_cron.rb
@@ -6,14 +6,14 @@ Rails.application.config.after_initialize do
   cron_jobs_hash = ActiveSupport::HashWithIndifferentAccess.new(
     production: {
       'Nightly PreCheck Mailer (Production)' => {
-        class: NightlyPrecheckMailerJob.name,
+        class: 'NightlyPrecheckMailerWorker',
         cron:  nightly_cron_schedule
       }
     },
 
     staging: {
       'Nightly PreCheck Mailer (Staging)' => {
-        class: NightlyPrecheckMailerJob.name,
+        class: 'NightlyPrecheckMailerWorker',
         cron:  nightly_cron_schedule
       }
     }


### PR DESCRIPTION

- Created NightlyPrecheckMailerWorker to wrap NightlyPrecheckMailerJob.perform_later
- Updated Sidekiq Cron config to use NightlyPrecheckMailerWorker instead of ActiveJob class
- Resolves NoMethodError undefined method `perform_async` when cron triggers ActiveJob directly