### PR TITLE
Arrival Scan: Cycle background color on reload and add input focus glow

### DIFF
--- a/app/assets/stylesheets/checkins.scss
+++ b/app/assets/stylesheets/checkins.scss
@@ -249,3 +249,23 @@ $checkin-info-bg: #e9ecef;
     }
   }
 } 
+.checkin-page.cycle-orange {
+  background-color: #F08020 !important;
+}
+
+.checkin-page.cycle-cyan {
+  background-color: #00C0D8 !important;
+}
+
+#family_id {
+  border: 1px solid #ccc;
+  padding: 8px;
+  border-radius: 4px;
+  transition: box-shadow 0.3s, border 0.3s;
+}
+
+#family_id:focus {
+  outline: none;
+  box-shadow: 0 0 8px 2px #FFD000;
+  border: 1px solid #FFD000;
+} 

--- a/app/views/checkins/new.html.erb
+++ b/app/views/checkins/new.html.erb
@@ -29,6 +29,16 @@
       
       // Focus on input when page loads
       input.focus();
+
+      // --- Arrival Scan Background Color Cycling ---
+      const body = document.body;
+      if (body.classList.contains('checkin-page')) {
+        let lastColor = localStorage.getItem('arrivalScanColor') || 'orange';
+        let nextColor = lastColor === 'orange' ? 'cyan' : 'orange';        
+        body.classList.remove('cycle-orange', 'cycle-cyan');        
+        body.classList.add('cycle-' + nextColor);        
+        localStorage.setItem('arrivalScanColor', nextColor);
+      }
     });
   </script>
 <% end %> 


### PR DESCRIPTION
- Implement background color cycling (orange/cyan) on the Arrival Scan page to visually indicate each scan/reload.
- Use localStorage to persist and toggle the color state between reloads.